### PR TITLE
Clarify individual services on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Blooming Financial | Professional Bookkeeping, Tax Services & Payroll in Bay Area</title>
-    <meta name="description" content="Affordable bookkeeping, tax preparation, payroll, and business consulting services for small businesses in Cupertino, San Francisco, and the Bay Area.">
+    <meta name="description" content="Affordable bookkeeping, tax preparation, payroll, and consulting services for individuals and small businesses in Cupertino, San Francisco, and the Bay Area.">
     
     <!-- Favicons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -99,8 +99,8 @@
         <div class="container mx-auto px-6">
             <div class="flex flex-col md:flex-row items-center">
                 <div class="md:w-1/2 mb-10 md:mb-0">
-                    <h1 class="text-4xl md:text-5xl font-bold mb-6">Financial Services That Help Your Business Grow</h1>
-                    <p class="text-xl mb-8">Professional bookkeeping, tax preparation, payroll, and consulting services tailored for small businesses in the Bay Area.</p>
+                    <h1 class="text-4xl md:text-5xl font-bold mb-6">Financial Services That Help Your Business Grow and Your Finances Flourish</h1>
+                    <p class="text-xl mb-8">Professional bookkeeping, tax preparation, payroll, and consulting services tailored for individuals and small businesses in the Bay Area.</p>
                     <div class="flex flex-col sm:flex-row space-y-4 sm:space-y-0 sm:space-x-4">
                         <a href="#consultation" class="bg-white text-blue-600 px-6 py-3 rounded-md font-medium hover:bg-gray-100 transition text-center">Book Free Consultation</a>
                         <a href="#services" class="border-2 border-white text-white px-6 py-3 rounded-md font-medium hover:bg-white hover:text-blue-600 transition text-center">Our Services</a>
@@ -142,7 +142,7 @@
         <div class="container mx-auto px-6">
             <div class="text-center mb-16">
                 <h2 class="text-3xl md:text-4xl font-bold text-blue-900 mb-4">Our Services</h2>
-                <p class="text-xl text-gray-600 max-w-2xl mx-auto">Comprehensive financial solutions designed to meet your business needs</p>
+                <p class="text-xl text-gray-600 max-w-2xl mx-auto">Comprehensive financial solutions designed to meet your business and personal financial needs</p>
             </div>
             
             <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
@@ -152,7 +152,7 @@
                         <i class="fas fa-calculator text-4xl"></i>
                     </div>
                     <h3 class="text-xl font-bold text-blue-900 mb-3">Bookkeeping</h3>
-                    <p class="text-gray-600 mb-4">Accurate financial records to keep your business compliant and informed.</p>
+                    <p class="text-gray-600 mb-4">Accurate financial records to keep your business or personal finances compliant and informed.</p>
                     <ul class="space-y-2 text-gray-600">
                         <li class="flex items-start">
                             <i class="fas fa-check text-blue-500 mt-1 mr-2"></i>
@@ -270,12 +270,12 @@
                 </div>
                 <div class="md:w-1/2">
                     <h2 class="text-3xl md:text-4xl font-bold text-blue-900 mb-6">About Blooming Financial</h2>
-                    <p class="text-gray-600 mb-4">Founded in 2024, Blooming Financial is dedicated to providing personalized financial services to small businesses throughout the Bay Area.</p>
-                    <p class="text-gray-600 mb-4">Our mission is to help entrepreneurs and small business owners navigate the complexities of financial management, so they can focus on what they do best - growing their business.</p>
+                    <p class="text-gray-600 mb-4">Founded in 2024, Blooming Financial is dedicated to providing personalized financial services to individuals and small businesses throughout the Bay Area.</p>
+                    <p class="text-gray-600 mb-4">Our mission is to help entrepreneurs, small business owners, and individuals navigate the complexities of financial management, so they can focus on what they do best - growing their business or achieving their personal financial goals.</p>
                     <p class="text-gray-600 mb-6">We take pride in our local roots and commitment to serving the communities of Cupertino, San Francisco, and surrounding areas with integrity and professionalism.</p>
                     
                     <div class="bg-blue-50 border-l-4 border-blue-500 p-4 mb-6">
-                        <p class="text-blue-900 font-medium">"We don't just crunch numbers - we build relationships and help our clients understand their financial position to make informed business decisions."</p>
+                        <p class="text-blue-900 font-medium">"We don't just crunch numbers - we build relationships and help our clients understand their financial position to make informed financial decisions."</p>
                     </div>
                     
                     <div class="flex items-center">
@@ -319,7 +319,7 @@
                         </div>
                         <div>
                             <h4 class="font-bold text-blue-900">Jennifer S.</h4>
-                            <p class="text-gray-600">Small Business Owner, Cupertino</p>
+                            <p class="text-gray-600">Individual Client, Cupertino</p>
                         </div>
                     </div>
                 </div>
@@ -387,7 +387,7 @@
                 <div class="md:flex">
                     <div class="md:w-1/2 bg-blue-600 text-white p-10">
                         <h2 class="text-3xl font-bold mb-6">Ready to Get Started?</h2>
-                        <p class="mb-6">Schedule your free 30-minute consultation to discuss your business needs and how we can help.</p>
+                        <p class="mb-6">Schedule your free 30-minute consultation to discuss your financial needs and how we can help.</p>
                         <div class="space-y-4">
                             <div class="flex items-start">
                                 <i class="fas fa-check-circle mt-1 mr-3"></i>
@@ -495,7 +495,7 @@
                             <i class="fas fa-chevron-down text-blue-500 transition-transform duration-300"></i>
                         </button>
                         <div class="faq-content hidden px-6 pb-6">
-                            <p class="text-gray-600">We’re based in the Bay Area and work closely with businesses in Cupertino, San Jose, Mountain View, Sunnyvale, Palo Alto, San Francisco, Berkeley and neighboring communities. In addition, we offer fully remote bookkeeping, payroll, tax, and consulting services to clients anywhere in California, so location is never a barrier to working with us.</p>
+                            <p class="text-gray-600">We’re based in the Bay Area and work closely with individuals and businesses in Cupertino, San Jose, Mountain View, Sunnyvale, Palo Alto, San Francisco, Berkeley and neighboring communities. In addition, we offer fully remote bookkeeping, payroll, tax, and consulting services to clients anywhere in California, so location is never a barrier to working with us.</p>
                         </div>
                     </div>
                     
@@ -694,7 +694,7 @@
         <div class="container mx-auto px-6">
             <div class="max-w-4xl mx-auto text-center">
                 <h2 class="text-3xl font-bold mb-6">Stay Updated</h2>
-                <p class="text-xl mb-8">Subscribe to our newsletter for financial tips, tax updates, and business insights delivered to your inbox monthly.</p>
+                <p class="text-xl mb-8">Subscribe to our newsletter for financial tips, tax updates, and insights delivered to your inbox monthly.</p>
                 
                 <form class="flex flex-col sm:flex-row max-w-md mx-auto sm:max-w-xl">
                     <input type="email" placeholder="Your email address" class="flex-grow px-4 py-3 rounded-md sm:rounded-r-none focus:outline-none text-gray-900">
@@ -714,7 +714,7 @@
                     <div class="text-2xl font-bold mb-4">
                         <span class="text-blue-400">Blooming</span> Financial
                     </div>
-                    <p class="text-blue-200 mb-4">Professional financial services for small businesses in the Bay Area.</p>
+                    <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in the Bay Area.</p>
                     <div class="flex space-x-4">
                         <a href="https://www.instagram.com/blooming.financial/" class="text-blue-300 hover:text-white text-xl" target="_blank" rel="noopener noreferrer">
                             <i class="fab fa-instagram"></i>


### PR DESCRIPTION
## Summary
- highlight support for individuals alongside small businesses in meta description and hero section
- update services, about, newsletter, and footer copy to mention personal financial needs
- adjust consultation CTA, FAQ, and testimonial to reference individual clients

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68983e4b4f54832ab15e8f71c38691f4