### PR TITLE
Add Client Portal link to navigation

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -46,6 +46,7 @@
           <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
           <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
           <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
         <!-- Mobile -->
@@ -64,6 +65,7 @@
       <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
       <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
       <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>

--- a/blogs/llc-s-corp-c-corp-california.html
+++ b/blogs/llc-s-corp-c-corp-california.html
@@ -60,6 +60,7 @@
           <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
           <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
           <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
         <div class="md:hidden">
@@ -78,6 +79,7 @@
       <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
       <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
       <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>

--- a/blogs/payroll-compliance-checklist-california.html
+++ b/blogs/payroll-compliance-checklist-california.html
@@ -60,6 +60,7 @@
           <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
           <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
           <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
         <div class="md:hidden">
@@ -78,6 +79,7 @@
       <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
       <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
       <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>

--- a/blogs/startup-tax-deductions.html
+++ b/blogs/startup-tax-deductions.html
@@ -60,6 +60,7 @@
           <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
           <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
           <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
         <div class="md:hidden">
@@ -78,6 +79,7 @@
       <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
       <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
       <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>

--- a/blogs/top-tax-credits-california-families.html
+++ b/blogs/top-tax-credits-california-families.html
@@ -60,6 +60,7 @@
           <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
           <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
           <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
         <div class="md:hidden">
@@ -78,6 +79,7 @@
       <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
       <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
       <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
                     <a href="#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
                     <a href="#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
                     <a href="/blogs" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+                    <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
                     <a href="#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
                 </div>
                 <div class="md:hidden">
@@ -89,6 +90,7 @@
             <a href="#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
             <a href="#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
             <a href="/blogs" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+            <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
             <a href="#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
         </div>
     </div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -39,6 +39,7 @@
       <div class="hidden md:flex items-center space-x-8 text-gray-700">
         <a href="/" class="nav-link">Home</a>
         <a href="/terms" class="nav-link">Terms</a>
+        <a href="https://portal.bloomingfinancials.com" class="nav-link" target="_blank" rel="noopener noreferrer">Client Portal</a>
         <a href="#do-not-sell" id="dnsTopLink" class="nav-link">Do Not Sell/Share</a>
       </div>
       <button id="openPrefsTop" class="md:hidden text-gray-700"><i class="fas fa-sliders-h text-xl"></i></button>

--- a/terms/index.html
+++ b/terms/index.html
@@ -48,6 +48,7 @@
       <div class="hidden md:flex items-center space-x-8 text-gray-700">
         <a href="/" class="nav-link">Home</a>
         <a href="/privacy" class="nav-link">Privacy</a>
+        <a href="https://portal.bloomingfinancials.com" class="nav-link" target="_blank" rel="noopener noreferrer">Client Portal</a>
         <a href="#do-not-sell" id="dnsTopLink" class="nav-link">Do Not Sell/Share</a>
       </div>
       <button id="openPrefsTop" class="md:hidden text-gray-700"><i class="fas fa-sliders-h text-xl"></i></button>


### PR DESCRIPTION
### Motivation
- Add a visible Client Portal link so clients can quickly access `https://portal.bloomingfinancials.com` from the site header and mobile menus across pages.

### Description
- Inserted `<a href="https://portal.bloomingfinancials.com" ...>Client Portal</a>` into the desktop navigation and mobile menu in `index.html` and the blog pages (`blogs/index.html`, `blogs/llc-s-corp-c-corp-california.html`, `blogs/payroll-compliance-checklist-california.html`, `blogs/startup-tax-deductions.html`, `blogs/top-tax-credits-california-families.html`).
- Added the same Client Portal link to the top navigation on `privacy/index.html` and `terms/index.html`.
- The link uses `target="_blank"` and `rel="noopener noreferrer"` to open in a new tab with proper security attributes.
- Eight HTML files were updated to keep navigation consistent across desktop and mobile views.

### Testing
- Served the site locally with `python -m http.server 8000` and confirmed the pages rendered successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:8000/` and captured `artifacts/client-portal-nav.png` to validate the link appears in the header, which completed successfully.
- No unit or integration tests were applicable for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b76c9e30832a88a5f2d70fa5776c)