### PR TITLE
Fix W-4/DE-4 blog image filename and wire up blog card and site nav

### DIFF
--- a/blogs/images/w4-de4.svg
+++ b/blogs/images/w4-de4.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1536 1024" role="img" aria-labelledby="title desc">
+  <title id="title">W-4 and DE-4 withholding forms illustration</title>
+  <desc id="desc">Stylized documents labeled W-4 and DE-4 with a checkmark, representing California payroll withholding forms.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e2e8f0" />
+      <stop offset="100%" stop-color="#f8fafc" />
+    </linearGradient>
+    <linearGradient id="accent" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e3a8a" />
+      <stop offset="100%" stop-color="#3b82f6" />
+    </linearGradient>
+  </defs>
+  <rect width="1536" height="1024" fill="url(#bg)" />
+  <rect x="220" y="190" width="520" height="640" rx="32" fill="#ffffff" stroke="#cbd5f5" stroke-width="8" />
+  <rect x="320" y="270" width="320" height="60" rx="12" fill="url(#accent)" />
+  <text x="480" y="312" font-size="36" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif" font-weight="700">W-4</text>
+  <rect x="300" y="370" width="360" height="20" rx="8" fill="#e2e8f0" />
+  <rect x="300" y="420" width="320" height="20" rx="8" fill="#e2e8f0" />
+  <rect x="300" y="470" width="280" height="20" rx="8" fill="#e2e8f0" />
+  <rect x="796" y="250" width="520" height="640" rx="32" fill="#ffffff" stroke="#cbd5f5" stroke-width="8" />
+  <rect x="896" y="330" width="320" height="60" rx="12" fill="url(#accent)" />
+  <text x="1056" y="372" font-size="36" text-anchor="middle" fill="#ffffff" font-family="Arial, sans-serif" font-weight="700">DE-4</text>
+  <rect x="876" y="430" width="360" height="20" rx="8" fill="#e2e8f0" />
+  <rect x="876" y="480" width="320" height="20" rx="8" fill="#e2e8f0" />
+  <rect x="876" y="530" width="280" height="20" rx="8" fill="#e2e8f0" />
+  <circle cx="768" cy="760" r="90" fill="url(#accent)" />
+  <path d="M726 760l28 30 56-66" fill="none" stroke="#ffffff" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" />
+</svg>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -46,6 +46,7 @@
           <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
           <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
           <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
         <!-- Mobile -->
@@ -64,6 +65,7 @@
       <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
       <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
       <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
@@ -150,6 +152,25 @@
             <h2 class="text-2xl font-bold text-blue-900 mb-3">5 Tax Deductions Every Startup Should Know</h2>
             <p class="text-gray-600 mb-4 flex-grow">Reduce your tax bill with these commonly overlooked write‑offs and keep more cash in the business.</p>
             <a href="/blogs/startup-tax-deductions.html" class="text-blue-600 font-medium hover:text-blue-700 transition self-start">Read more →</a>
+          </div>
+        </article>
+
+        <article class="bg-gray-50 rounded-lg shadow-md overflow-hidden flex flex-col" data-cat="business">
+          <div class="relative w-full overflow-hidden aspect-[1536/1024] bg-slate-100">
+            <img
+              src="images/w4-de4.svg"
+              alt="W-4 and DE-4 withholding forms"
+              class="absolute inset-0 h-full w-full object-cover object-center"
+              width="1536" height="1024" loading="lazy" decoding="async"
+            />
+          </div>
+          <div class="p-6 flex flex-col flex-grow">
+            <p class="text-sm text-blue-600 font-semibold mb-2">Payroll • Feb 18 2025</p>
+            <h2 class="text-2xl font-bold text-blue-900 mb-3">W-4 &amp; DE-4 Withholding Guide for California Employees</h2>
+            <p class="text-gray-600 mb-4 flex-grow">
+              A step-by-step guide to setting up federal and California withholding correctly for new hires.
+            </p>
+            <a href="/blogs/w4-de4-withholding-guide-california.html" class="text-blue-600 font-medium hover:text-blue-700 transition self-start">Read more →</a>
           </div>
         </article>
 

--- a/blogs/llc-s-corp-c-corp-california.html
+++ b/blogs/llc-s-corp-c-corp-california.html
@@ -60,6 +60,7 @@
           <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
           <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
           <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
         <div class="md:hidden">
@@ -78,6 +79,7 @@
       <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
       <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
       <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>

--- a/blogs/payroll-compliance-checklist-california.html
+++ b/blogs/payroll-compliance-checklist-california.html
@@ -60,6 +60,7 @@
           <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
           <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
           <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
         <div class="md:hidden">
@@ -78,6 +79,7 @@
       <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
       <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
       <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>

--- a/blogs/startup-tax-deductions.html
+++ b/blogs/startup-tax-deductions.html
@@ -60,6 +60,7 @@
           <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
           <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
           <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
         <div class="md:hidden">
@@ -78,6 +79,7 @@
       <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
       <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
       <a href="/blogs" class="nav-link text-blue-600 font-semibold">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>

--- a/blogs/w4-de4-withholding-guide-california.html
+++ b/blogs/w4-de4-withholding-guide-california.html
@@ -10,14 +10,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-  <title>Top Tax Credits California Families Shouldn't Miss | Blooming Financial</title>
-  <meta name="description" content="Clear guide to California and federal tax credits for families, including CalEITC, Young Child Tax Credit, Foster Youth Tax Credit, child and dependent care, renter credit, education credits, and health coverage credit tips." />
-  <link rel="canonical" href="https://www.bloomingfinancials.com/blogs/top-tax-credits-california-families" />
+  <title>W-4 &amp; DE-4 Withholding Guide for California Employees | Blooming Financial</title>
+  <meta name="description" content="A clear, employer-friendly guide to handling W-4 and DE-4 withholding for California employees, including how to read the forms, set up payroll, and avoid common mistakes." />
+  <link rel="canonical" href="https://www.bloomingfinancials.com/blogs/w4-de4-withholding-guide-california" />
 
   <meta property="og:type" content="article" />
-  <meta property="og:title" content="Top Tax Credits California Families Shouldn't Miss" />
-  <meta property="og:description" content="A family-friendly overview of California and federal credits that can lower your tax bill or boost your refund." />
-  <meta property="og:url" content="https://www.bloomingfinancials.com/blogs/top-tax-credits-california-families" />
+  <meta property="og:title" content="W-4 &amp; DE-4 Withholding Guide for California Employees" />
+  <meta property="og:description" content="Step-by-step guidance for W-4 and DE-4 withholding setup in California payroll." />
+  <meta property="og:url" content="https://www.bloomingfinancials.com/blogs/w4-de4-withholding-guide-california" />
   <meta property="og:site_name" content="Blooming Financial" />
 
   <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
@@ -87,9 +87,9 @@
   <!-- HERO -->
   <header class="hero-gradient text-white py-20">
     <div class="container mx-auto px-6 text-center max-w-3xl">
-      <p class="text-sm text-blue-200 mb-2">Individuals • Feb 4 2025 • ~7 min read</p>
-      <h1 class="text-4xl md:text-5xl font-bold mb-6">Top Tax Credits California Families Shouldn't Miss</h1>
-      <p class="text-xl">Credits reduce tax dollar for dollar. Use this guide to review the California and federal credits most families look at before filing.</p>
+      <p class="text-sm text-blue-200 mb-2">Payroll • Feb 18 2025 • ~7 min read</p>
+      <h1 class="text-4xl md:text-5xl font-bold mb-6">W-4 &amp; DE-4 Withholding Guide for California Employees</h1>
+      <p class="text-xl">Set up federal and California withholding correctly, avoid payroll surprises, and keep your team compliant from day one.</p>
     </div>
   </header>
 
@@ -98,107 +98,114 @@
     <div class="container mx-auto px-6 max-w-3xl">
       <!-- Intro -->
       <div class="note rounded-md p-5 mb-8">
-        <p class="text-gray-800"><strong>Quick note:</strong> This is educational only. Eligibility and amounts change from year to year. We will confirm current rules when we prepare your return.</p>
+        <p class="text-gray-800"><strong>Quick note:</strong> This guide is for general education. Always follow current IRS and California EDD instructions and keep signed forms on file.</p>
       </div>
 
       <!-- TOC -->
       <div class="border rounded-md p-5 mb-10">
         <h2 class="text-lg font-semibold text-blue-900 mb-3">Contents</h2>
         <ul class="toc space-y-2 list-disc list-inside">
-          <li><a href="#california-credits">California credits to review</a></li>
-          <li><a href="#federal-credits">Important federal credits</a></li>
-          <li><a href="#coordination-tips">Coordination tips</a></li>
-          <li><a href="#checklist">What to gather</a></li>
+          <li><a href="#overview">W-4 vs. DE-4 overview</a></li>
+          <li><a href="#when-collect">When to collect forms</a></li>
+          <li><a href="#w4-basics">W-4 basics for employers</a></li>
+          <li><a href="#de4-basics">DE-4 basics for employers</a></li>
+          <li><a href="#setup-payroll">Setting up payroll withholding</a></li>
+          <li><a href="#common-issues">Common issues to avoid</a></li>
           <li><a href="#faq">FAQ</a></li>
         </ul>
       </div>
 
-      <!-- California credits -->
-      <section id="california-credits" class="mb-12">
-        <h2 class="text-2xl font-bold text-blue-900 mb-4">California credits to review</h2>
-
-        <h3 class="text-xl font-semibold text-blue-900 mb-2">California Earned Income Tax Credit (CalEITC)</h3>
-        <p class="text-gray-700 mb-3">
-          For low to moderate earned income from wages or self-employment. The credit amount generally increases with qualifying children and phases out at higher incomes. File a California return and complete the CalEITC worksheet when eligible.
+      <!-- Overview -->
+      <section id="overview" class="mb-12">
+        <h2 class="text-2xl font-bold text-blue-900 mb-4">W-4 vs. DE-4 overview</h2>
+        <p class="text-gray-700 mb-4">
+          The <strong>W-4</strong> tells you how much <em>federal</em> income tax to withhold. The <strong>DE-4</strong> does the same for
+          <em>California</em> state income tax. Employers use both forms to configure payroll withholding and must keep signed copies on file.
         </p>
-
-        <div class="cali rounded-md p-4 mb-6">
-          <p class="font-semibold mb-1">Good to know</p>
-          <p class="text-gray-700">
-            In recent years California has allowed certain ITIN filers to claim CalEITC if other requirements are met. Confirm current eligibility at filing time since rules can change.
-          </p>
-        </div>
-
-        <h3 class="text-xl font-semibold text-blue-900 mb-2">Young Child Tax Credit (YCTC)</h3>
-        <p class="text-gray-700 mb-3">
-          Additional refundable credit for families who qualify for CalEITC and have a child under age 6 at year end. It can significantly increase refunds for eligible households.
-        </p>
-
-        <h3 class="text-xl font-semibold text-blue-900 mb-2">Foster Youth Tax Credit (FYTC)</h3>
-        <p class="text-gray-700 mb-3">
-          Credit intended to support eligible current or former foster youth who also qualify for CalEITC. Refundability and age criteria apply. Review the current state instructions to confirm.
-        </p>
-
-        <h3 class="text-xl font-semibold text-blue-900 mb-2">California Child and Dependent Care Expenses Credit</h3>
-        <p class="text-gray-700 mb-3">
-          Based on a percentage of qualifying care expenses so you can work or look for work. Keep provider information, payment records, and details for the dependent who received care.
-        </p>
-
-        <h3 class="text-xl font-semibold text-blue-900 mb-2">California Renter's Credit</h3>
-        <p class="text-gray-700 mb-6">
-          For eligible renters who paid rent on a principal California residence for at least half of the year and meet income limits. You generally cannot claim it if you claimed a homeowner property tax exemption for that year.
-        </p>
-      </section>
-
-      <!-- Federal credits -->
-      <section id="federal-credits" class="mb-12">
-        <h2 class="text-2xl font-bold text-blue-900 mb-4">Important federal credits</h2>
-        <ul class="list-disc list-inside text-gray-700 space-y-3 mb-6">
-          <li><strong>Child Tax Credit (CTC):</strong> Per child credit with phaseouts at higher incomes. A portion can be refundable depending on current law.</li>
-          <li><strong>Child and Dependent Care Credit:</strong> For daycare, preschool, after-school programs, or summer day camp needed so you can work or look for work.</li>
-          <li><strong>American Opportunity Tax Credit (AOTC):</strong> For qualified undergraduate tuition and required fees. Partially refundable.</li>
-          <li><strong>Lifetime Learning Credit (LLC):</strong> For many post-secondary courses and programs, including part-time or graduate study.</li>
-          <li><strong>Saver's Credit:</strong> For eligible retirement contributions to accounts like an IRA or 401(k), subject to income limits.</li>
-          <li><strong>Premium Tax Credit:</strong> For health insurance purchased through the exchange. If you received advance payments, reconcile using Form 1095-A.</li>
-        </ul>
-
-        <div class="warning rounded-md p-4">
-          <p class="font-semibold mb-1">Documentation matters</p>
-          <p class="text-gray-700">Education credits rely on Form 1098-T and your school account statement. For Premium Tax Credit reconciliation, you need Form 1095-A. Keep childcare provider details on hand.</p>
+        <div class="cali rounded-md p-4">
+          <p class="font-semibold mb-1">California call-out</p>
+          <p class="text-gray-700">California has its own rules and allowance system. Even if an employee completes a W-4, you still need a DE-4 for state withholding.</p>
         </div>
       </section>
 
-      <!-- Coordination tips -->
-      <section id="coordination-tips" class="mb-12">
-        <h2 class="text-2xl font-bold text-blue-900 mb-4">Coordination tips</h2>
+      <!-- When to collect -->
+      <section id="when-collect" class="mb-12">
+        <h2 class="text-2xl font-bold text-blue-900 mb-4">When to collect forms</h2>
         <ul class="list-disc list-inside text-gray-700 space-y-2">
-          <li>Credits can be refundable or nonrefundable. Refundable credits can increase your refund even if you do not owe tax.</li>
-          <li>Education expenses cannot be double counted. If you use qualified tuition for AOTC, you cannot also use the same dollars for a 529 distribution exclusion.</li>
-          <li>If you receive advance payments of the Premium Tax Credit, reconcile accurately to avoid unexpected balances due.</li>
-          <li>For separated parents, review who claims the child since that can affect CTC, EITC, and care credits.</li>
-          <li>California does not conform to every federal rule. State and federal results can differ even with the same facts.</li>
+          <li>At onboarding, before the first payroll run.</li>
+          <li>Whenever an employee updates withholding due to life changes.</li>
+          <li>After IRS/EDD releases updated versions for a new tax year.</li>
         </ul>
       </section>
 
-      <!-- Checklist -->
-      <section id="checklist" class="mb-12">
-        <h2 class="text-2xl font-bold text-blue-900 mb-4">What to gather</h2>
-        <div class="note rounded-md p-4">
+      <!-- W-4 basics -->
+      <section id="w4-basics" class="mb-12">
+        <h2 class="text-2xl font-bold text-blue-900 mb-4">W-4 basics for employers</h2>
+        <p class="text-gray-700 mb-3">
+          The IRS redesigned the W-4 to remove withholding allowances. Employees now use a multi-step form that captures filing status, multiple jobs,
+          dependents, other income, and deductions. Payroll systems translate these inputs into withholding amounts.
+        </p>
+        <div class="pros rounded-md p-4 mb-4">
+          <p class="font-semibold mb-2">What you should check</p>
           <ul class="list-disc list-inside text-gray-700 space-y-1">
-            <li>W-2s and 1099s for wages and other income</li>
-            <li>Social Security numbers or ITINs for everyone on the return</li>
-            <li>Childcare provider name, address, and taxpayer ID, plus receipts</li>
-            <li>School billing statements and Form 1098-T for education credits</li>
-            <li>Form 1095-A for exchange health coverage</li>
-            <li>Lease agreements or rent receipts if claiming the renter credit</li>
+            <li>Form is signed and dated.</li>
+            <li>Filing status is selected (Step 1).</li>
+            <li>Any extra withholding amounts are clearly stated.</li>
           </ul>
         </div>
+        <div class="warning rounded-md p-4">
+          <p class="font-semibold mb-1">No blank forms</p>
+          <p class="text-gray-700">If an employee does not provide a W-4, withhold at the default rate: single with no adjustments.</p>
+        </div>
+      </section>
+
+      <!-- DE-4 basics -->
+      <section id="de4-basics" class="mb-12">
+        <h2 class="text-2xl font-bold text-blue-900 mb-4">DE-4 basics for employers</h2>
+        <p class="text-gray-700 mb-3">
+          The DE-4 uses allowances and additional withholding amounts. It is separate from the federal W-4 and feeds directly into California state
+          withholding calculations in your payroll system.
+        </p>
+        <div class="pros rounded-md p-4 mb-4">
+          <p class="font-semibold mb-2">Key fields to review</p>
+          <ul class="list-disc list-inside text-gray-700 space-y-1">
+            <li>Marital status selection.</li>
+            <li>Regular allowances and estimated deductions.</li>
+            <li>Any additional withholding amount.</li>
+          </ul>
+        </div>
+        <div class="cali rounded-md p-4">
+          <p class="font-semibold mb-1">EDD guidance</p>
+          <p class="text-gray-700">If the employee does not submit a DE-4, withhold as single with zero allowances.</p>
+        </div>
+      </section>
+
+      <!-- Payroll setup -->
+      <section id="setup-payroll" class="mb-12">
+        <h2 class="text-2xl font-bold text-blue-900 mb-4">Setting up payroll withholding</h2>
+        <ol class="list-decimal list-inside text-gray-700 space-y-2">
+          <li>Collect signed W-4 and DE-4 forms.</li>
+          <li>Enter filing status, allowances, and extra withholding into payroll.</li>
+          <li>Run a test payroll to confirm federal and CA withholding.</li>
+          <li>Store forms securely and update when employees submit changes.</li>
+        </ol>
+      </section>
+
+      <!-- Common issues -->
+      <section id="common-issues" class="mb-12">
+        <h2 class="text-2xl font-bold text-blue-900 mb-4">Common issues to avoid</h2>
+        <ul class="list-disc list-inside text-gray-700 space-y-2">
+          <li>Using old forms after updated versions are released.</li>
+          <li>Missing signatures or dates on submitted forms.</li>
+          <li>Applying state allowances to federal withholding or vice versa.</li>
+          <li>Not storing forms securely or losing them during audits.</li>
+        </ul>
       </section>
 
       <!-- CTA -->
       <section class="rounded-lg border p-6 mb-12">
-        <h3 class="text-xl font-semibold text-blue-900 mb-2">Want help maximizing credits this year?</h3>
-        <p class="text-gray-700 mb-4">We will check your eligibility for California and federal credits, prepare an accurate return, and explain your results in plain English.</p>
+        <h3 class="text-xl font-semibold text-blue-900 mb-2">Need help setting up payroll correctly?</h3>
+        <p class="text-gray-700 mb-4">We handle onboarding, withholding setup, and compliance so you can focus on your business.</p>
         <a href="/#consultation" class="inline-block bg-blue-600 text-white px-5 py-2 rounded-md hover:bg-blue-700 transition">Book a free consultation</a>
       </section>
 
@@ -207,20 +214,16 @@
         <h2 class="text-2xl font-bold text-blue-900 mb-4">FAQ</h2>
         <div class="space-y-6">
           <div>
-            <h3 class="font-semibold text-blue-900">Can ITIN filers qualify for CalEITC?</h3>
-            <p class="text-gray-700">California has allowed certain ITIN filers to qualify in recent years if other requirements are met. Confirm the current rules for the tax year you are filing.</p>
+            <h3 class="font-semibold text-blue-900">Do we submit W-4 or DE-4 forms to the IRS or EDD?</h3>
+            <p class="text-gray-700">No. Keep them on file and provide them only if requested during audits.</p>
           </div>
           <div>
-            <h3 class="font-semibold text-blue-900">Do I need income to claim child and dependent care credits?</h3>
-            <p class="text-gray-700">Yes, the care credits are tied to earned income. There are additional rules when one spouse is a full-time student or disabled.</p>
+            <h3 class="font-semibold text-blue-900">How often can employees update withholding?</h3>
+            <p class="text-gray-700">Any time. You should apply changes no later than the first payroll period ending after the forms are received.</p>
           </div>
           <div>
-            <h3 class="font-semibold text-blue-900">Can I claim both AOTC and LLC in the same year?</h3>
-            <p class="text-gray-700">Not for the same student. You can choose which credit fits better for each eligible student in your household that year.</p>
-          </div>
-          <div>
-            <h3 class="font-semibold text-blue-900">Does California allow HSA deductions?</h3>
-            <p class="text-gray-700">No. California does not allow a deduction for HSA contributions even though federal law does. This is a common federal vs. state difference.</p>
+            <h3 class="font-semibold text-blue-900">Do we need both forms for remote employees in California?</h3>
+            <p class="text-gray-700">Yes. California withholding applies to wages for employees who live and work in California.</p>
           </div>
         </div>
       </section>
@@ -234,10 +237,10 @@
     <div class="container mx-auto px-6 max-w-5xl">
       <h2 class="text-2xl font-bold text-blue-900 mb-6">You might also like</h2>
       <div class="grid md:grid-cols-3 gap-6">
-        <a href="/blogs/startup-tax-deductions" class="block border rounded-lg p-5 hover:shadow-md transition bg-white">
-          <div class="text-sm text-blue-700 mb-1">Tax • Startups</div>
-          <div class="font-semibold text-gray-900 mb-2">5 Tax Deductions Every Startup Should Know</div>
-          <p class="text-gray-600 text-sm">Founder-friendly write-offs and California call-outs.</p>
+        <a href="/blogs/payroll-compliance-checklist-california" class="block border rounded-lg p-5 hover:shadow-md transition bg-white">
+          <div class="text-sm text-blue-700 mb-1">Payroll</div>
+          <div class="font-semibold text-gray-900 mb-2">Payroll Compliance Checklist for California Employers</div>
+          <p class="text-gray-600 text-sm">Stay penalty-free with month-by-month tasks and filings.</p>
         </a>
         <a href="/blogs/llc-s-corp-c-corp-california" class="block border rounded-lg p-5 hover:shadow-md transition bg-white">
           <div class="text-sm text-blue-700 mb-1">Entity Choice • California</div>
@@ -247,7 +250,7 @@
         <a href="/blogs" class="block border rounded-lg p-5 hover:shadow-md transition bg-white">
           <div class="text-sm text-blue-700 mb-1">More</div>
           <div class="font-semibold text-gray-900 mb-2">Browse all articles</div>
-          <p class="text-gray-600 text-sm">Actionable finance, tax tips, and money basics.</p>
+          <p class="text-gray-600 text-sm">Actionable finance, tax tips, and growth strategies.</p>
         </a>
       </div>
     </div>
@@ -311,43 +314,48 @@
   {
     "@context": "https://schema.org",
     "@type": "BlogPosting",
-    "headline": "Top Tax Credits California Families Shouldn't Miss",
-    "description": "California and federal credits that can lower your tax bill or boost your refund, explained in plain English.",
+    "headline": "W-4 & DE-4 Withholding Guide for California Employees",
+    "description": "Step-by-step guidance for W-4 and DE-4 withholding setup in California payroll.",
     "author": { "@type": "Organization", "name": "Blooming Financial" },
     "publisher": {
       "@type": "Organization",
       "name": "Blooming Financial",
       "logo": { "@type": "ImageObject", "url": "https://www.bloomingfinancials.com/favicon-32x32.png" }
     },
-    "datePublished": "2025-02-01",
-    "dateModified": "2025-02-01",
+    "datePublished": "2025-02-18",
+    "dateModified": "2025-02-18",
     "mainEntityOfPage": {
       "@type": "WebPage",
-      "@id": "https://www.bloomingfinancials.com/blogs/top-tax-credits-california-families"
+      "@id": "https://www.bloomingfinancials.com/blogs/w4-de4-withholding-guide-california"
     }
   }
   </script>
 
   <!-- SCRIPTS -->
   <script>
+    // Mobile nav toggle
     const mobileToggle = document.getElementById('mobileToggle');
     const mobileMenu   = document.getElementById('mobileMenu');
-    mobileToggle.addEventListener('click', () => {
-      const hidden = mobileMenu.classList.contains('-translate-y-full');
-      if (hidden) {
-        mobileMenu.classList.remove('-translate-y-full');
-        mobileMenu.classList.add('translate-y-0','shadow-lg');
-      } else {
-        mobileMenu.classList.add('-translate-y-full');
-        mobileMenu.classList.remove('translate-y-0','shadow-lg');
-      }
-    });
-    document.querySelectorAll('#mobileMenu a').forEach(link => {
-      link.addEventListener('click', () => {
-        mobileMenu.classList.add('-translate-y-full');
-        mobileMenu.classList.remove('translate-y-0','shadow-lg');
+    if (mobileToggle) {
+      mobileToggle.addEventListener('click', () => {
+        const hidden = mobileMenu.classList.contains('-translate-y-full');
+        if (hidden) {
+          mobileMenu.classList.remove('-translate-y-full');
+          mobileMenu.classList.add('translate-y-0','shadow-lg');
+        } else {
+          mobileMenu.classList.add('-translate-y-full');
+          mobileMenu.classList.remove('translate-y-0','shadow-lg');
+        }
       });
-    });
+      document.querySelectorAll('#mobileMenu a').forEach(link => {
+        link.addEventListener('click', () => {
+          mobileMenu.classList.add('-translate-y-full');
+          mobileMenu.classList.remove('translate-y-0','shadow-lg');
+        });
+      });
+    }
+
+    // Back to top
     const backToTop = document.getElementById('backToTop');
     window.addEventListener('scroll', () => {
       if (window.pageYOffset > 300) backToTop.classList.remove('hidden');

--- a/index.html
+++ b/index.html
@@ -64,6 +64,7 @@
                     <a href="#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
                     <a href="#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
                     <a href="/blogs" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+                    <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
                     <a href="#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
                 </div>
                 <div class="md:hidden">
@@ -89,6 +90,7 @@
             <a href="#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
             <a href="#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
             <a href="/blogs" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+            <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
             <a href="#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
         </div>
     </div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -39,6 +39,7 @@
       <div class="hidden md:flex items-center space-x-8 text-gray-700">
         <a href="/" class="nav-link">Home</a>
         <a href="/terms" class="nav-link">Terms</a>
+        <a href="https://portal.bloomingfinancials.com" class="nav-link" target="_blank" rel="noopener noreferrer">Client Portal</a>
         <a href="#do-not-sell" id="dnsTopLink" class="nav-link">Do Not Sell/Share</a>
       </div>
       <button id="openPrefsTop" class="md:hidden text-gray-700"><i class="fas fa-sliders-h text-xl"></i></button>

--- a/terms/index.html
+++ b/terms/index.html
@@ -48,6 +48,7 @@
       <div class="hidden md:flex items-center space-x-8 text-gray-700">
         <a href="/" class="nav-link">Home</a>
         <a href="/privacy" class="nav-link">Privacy</a>
+        <a href="https://portal.bloomingfinancials.com" class="nav-link" target="_blank" rel="noopener noreferrer">Client Portal</a>
         <a href="#do-not-sell" id="dnsTopLink" class="nav-link">Do Not Sell/Share</a>
       </div>
       <button id="openPrefsTop" class="md:hidden text-gray-700"><i class="fas fa-sliders-h text-xl"></i></button>


### PR DESCRIPTION
### Motivation
- Ensure the W-4/DE-4 blog post is fully wired: use the correct SVG asset name so the blog card image loads and the post displays correctly. 
- Keep site navigation consistent by adding the existing Client Portal link to top nav and mobile menus across site pages.

### Description
- Renamed and added the SVG asset as `blogs/images/w4-de4.svg` and removed the double-extension variant. 
- Updated the blog listing at `blogs/index.html` to reference `images/w4-de4.svg` and included the W-4/DE-4 article card in the grid. 
- Added the new blog page `blogs/w4-de4-withholding-guide-california.html` with hero, content, TOC, related posts, and structured data. 
- Added the `Client Portal` link (with `target="_blank" rel="noopener noreferrer"`) to desktop and mobile navigation in `index.html`, blog pages, `privacy/index.html`, and `terms/index.html`.

### Testing
- Started a local server with `python -m http.server 8000` and ran a Playwright script that loaded `http://127.0.0.1:8000/blogs/` and saved a screenshot to `artifacts/blogs-w4-de4-card.png`, which completed successfully. 
- Inspected `blogs/images/w4-de4.svg` to confirm the SVG content is present and verified `blogs/index.html` now references `images/w4-de4.svg`, both of which are correct. 
- No unit tests were applicable for these static HTML/SVG changes and the manual/automated site render check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b76c9e30832a88a5f2d70fa5776c)