### PR TITLE
Normalize legal link routing in terms page

### DIFF
--- a/terms/index.html
+++ b/terms/index.html
@@ -93,7 +93,7 @@
       <p>Scheduling a consultation or receiving a quote does not obligate either party to proceed. Any services, fees, deliverables, timeframes, confidentiality obligations, and data-handling details will be specified in an Engagement Agreement. Estimates are not guarantees. We may decline or terminate a prospective engagement at our discretion consistent with applicable ethics rules.</p>
 
       <h2 id="privacy">9. Privacy</h2>
-      <p>Your use of the Site is also subject to our <a href="/privacy.html" class="text-blue-600 underline">Privacy Policy</a>. For tax and certain financial services, laws such as the Gramm-Leach-Bliley Act (GLBA) and Internal Revenue Code §7216 may apply once you become a client.</p>
+      <p>Your use of the Site is also subject to our <a href="/privacy" class="text-blue-600 underline">Privacy Policy</a>. For tax and certain financial services, laws such as the Gramm-Leach-Bliley Act (GLBA) and Internal Revenue Code §7216 may apply once you become a client.</p>
 
       <h2 id="warranty">10. Disclaimers</h2>
       <p>THE SITE IS PROVIDED ON AN "AS IS" AND "AS AVAILABLE" BASIS. TO THE MAXIMUM EXTENT PERMITTED BY LAW, WE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, TITLE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE SITE WILL BE UNINTERRUPTED, SECURE, OR ERROR-FREE, OR THAT DEFECTS WILL BE CORRECTED.</p>


### PR DESCRIPTION
### Motivation
- Ensure internal legal links in the Terms page match the site-wide route-style paths by replacing legacy `.html` anchors (change `/privacy.html` to `/privacy`).

### Description
- Updated the Privacy Policy anchor in `terms/index.html` (the `h2#privacy` section) from `/privacy.html` to `/privacy` and scanned the file to ensure internal legal links use `/privacy` and `/terms` routing.

### Testing
- Searched `terms/index.html` for legacy `.html` links with `rg` (for example `rg -n 'href="/[^"]+\.html"' terms/index.html`) and inspected the `git diff` output to confirm the single intended change, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02955b57a88330823acbf188aa450c)