### PR TITLE
Add visible Effective Date callout to Privacy and Terms pages

### DIFF
--- a/privacy/index.html
+++ b/privacy/index.html
@@ -55,6 +55,7 @@
 
   <main class="container mx-auto px-6 py-12">
     <article class="prose prose-blue max-w-none">
+      <p class="inline-flex items-center mt-2 mb-6 px-4 py-2 rounded-md bg-blue-50 border border-blue-200 text-blue-900 font-semibold">Effective Date: May 12, 2026</p>
       <p class="text-gray-700 text-lg">Thank you for visiting Blooming Financial ("Blooming Financial," "we," "us," or "our"). We provide bookkeeping, payroll, tax preparation, and related consulting services to individuals and small businesses. This Privacy Policy explains how we collect, use, disclose, and safeguard personal information when you use our website, contact us, subscribe to our newsletter, or engage our services.</p>
       <p class="text-gray-700">Questions or requests? Email <a class="text-blue-600 underline" href="mailto:info@bloomingfinancials.com">info@bloomingfinancials.com</a> or call <a class="text-blue-600 underline" href="tel:+14083654671">(408) 365-4671</a>.</p>
 

--- a/terms/index.html
+++ b/terms/index.html
@@ -64,6 +64,7 @@
 
   <main class="container mx-auto px-6 py-12">
     <article class="prose prose-blue max-w-none text-gray-700 leading-relaxed">
+      <p class="inline-flex items-center mt-2 mb-6 px-4 py-2 rounded-md bg-blue-50 border border-blue-200 text-blue-900 font-semibold">Effective Date: May 12, 2026</p>
       <p>Welcome to Blooming Financial ("Blooming Financial," "we," "us," or "our"). These Terms of Service ("Terms") govern your access to and use of our website, content, and features (collectively, the "Site"). By using the Site, you agree to these Terms. If you do not agree, do not use the Site.</p>
 
       <hr class="my-10" />


### PR DESCRIPTION
### Motivation
- Make the policy and terms effective date clearly visible on each page so visitors can immediately see when the document was last updated. 
- Ensure consistent placement and styling between the Privacy Policy and Terms pages so references like “Effective Date above” remain accurate and unambiguous.

### Description
- Inserted an `Effective Date: May 12, 2026` callout paragraph at the top of the main article content in `privacy/index.html`. 
- Inserted the identical `Effective Date: May 12, 2026` callout paragraph at the top of the main article content in `terms/index.html`. 
- Used the same Tailwind utility classes on both pages (`inline-flex items-center mt-2 mb-6 px-4 py-2 rounded-md bg-blue-50 border border-blue-200 text-blue-900 font-semibold`) to keep visual placement and styling consistent. 
- Left existing “Changes” language intact so the documented update process remains consistent with the displayed effective date.

### Testing
- Verified the changes with `git diff -- privacy/index.html terms/index.html` and confirmed the new callout lines appear in both files (diff shown). 
- Committed the updates successfully with `git commit -m "Add visible effective date to privacy and terms pages"`. 
- Inspected the files with `nl -ba privacy/index.html` and `nl -ba terms/index.html` to confirm the callout is placed immediately under each page hero/title, and those checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0295abb8a88330b5f129d34acc5a93)