### PR TITLE
Disambiguate homepage Tax Preparation card

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@
                         <i class="fas fa-file-invoice-dollar text-4xl"></i>
                     </div>
                     <h3 class="text-xl font-bold text-blue-900 mb-3">Tax Preparation</h3>
-                    <p class="text-gray-600 mb-4">Comprehensive tax services to keep you compliant and maximize deductions.</p>
+                    <p class="text-gray-600 mb-4">Comprehensive tax services for individuals and small businesses &mdash; federal, California, and multi-state filings.</p>
                     <ul class="space-y-2 text-gray-600">
                         <li class="flex items-start">
                             <i class="fas fa-check text-blue-500 mt-1 mr-2"></i>
@@ -238,7 +238,7 @@
                             <span>Electronic filing & compliance</span>
                         </li>
                     </ul>
-                    <a href="/services/individual-tax-preparation/" class="inline-block mt-6 text-blue-600 font-medium hover:text-blue-700 transition">Learn more →</a>
+                    <a href="/services/" class="inline-block mt-6 text-blue-600 font-medium hover:text-blue-700 transition">Learn more →</a>
                 </div>
 
                 <!-- Payroll Card -->


### PR DESCRIPTION
Point the Tax Preparation card's "Learn more" to /services/ (the hub) instead of /services/individual-tax-preparation/ so visitors can choose between Individual and Business tax preparation. Update the card body to mention both individuals and small businesses, plus federal / California / multi-state filings, so the dual scope is clear before the click. The other three homepage cards (Bookkeeping, Payroll, Business Consulting) keep their direct deep links since each corresponds 1:1 to a single detail page.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf