### PR TITLE
Bump blog lastmod values and use http xmlns in sitemap

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.bloomingfinancials.com/</loc>
     <lastmod>2026-05-14</lastmod>
@@ -55,43 +55,43 @@
 
   <url>
     <loc>https://www.bloomingfinancials.com/blogs/startup-tax-deductions.html</loc>
-    <lastmod>2024-11-10</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://www.bloomingfinancials.com/blogs/payroll-compliance-checklist-california.html</loc>
-    <lastmod>2025-01-15</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://www.bloomingfinancials.com/blogs/top-tax-credits-california-families.html</loc>
-    <lastmod>2025-02-04</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://www.bloomingfinancials.com/blogs/llc-s-corp-c-corp-california.html</loc>
-    <lastmod>2025-07-27</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://www.bloomingfinancials.com/blogs/w4-de4-withholding-guide-california.html</loc>
-    <lastmod>2026-01-23</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://www.bloomingfinancials.com/blogs/rsus-stock-sales-explained.html</loc>
-    <lastmod>2026-01-24</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <priority>0.6</priority>
   </url>
 
   <url>
     <loc>https://www.bloomingfinancials.com/blogs/2025-tax-law-changes.html</loc>
-    <lastmod>2026-02-22</lastmod>
+    <lastmod>2026-05-14</lastmod>
     <priority>0.6</priority>
   </url>
 


### PR DESCRIPTION
All seven blog articles received "Related service" callouts and em-dash rewrites in this branch, so their lastmod dates move to today (2026-05-14) to signal the updates to search engines. The urlset namespace switches from https to http to match the sitemap protocol's canonical xmlns URI.