### PR TITLE
Standardize footer tagline, Services list, and hours across every page

### DIFF
--- a/blogs/2025-tax-law-changes.html
+++ b/blogs/2025-tax-law-changes.html
@@ -504,7 +504,7 @@
       <div class="grid md:grid-cols-4 gap-8">
         <div>
           <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200 mb-4">Professional financial services for small businesses and individuals in California.</p>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
           <div class="flex space-x-4">
             <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
             <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
@@ -514,9 +514,12 @@
         <div>
           <h3 class="font-bold text-lg mb-4">Services</h3>
           <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
             <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
-            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Tax Preparation</a></li>
-            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll Services</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
             <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
           </ul>
         </div>
@@ -536,6 +539,7 @@
           <ul class="space-y-2 text-blue-200">
             <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
             <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
           </ul>
         </div>
       </div>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -272,7 +272,7 @@
       <div class="grid md:grid-cols-4 gap-8">
         <div>
           <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in the Bay Area.</p>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
           <div class="flex space-x-4">
             <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
             <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
@@ -282,9 +282,12 @@
         <div>
           <h3 class="font-bold text-lg mb-4">Services</h3>
           <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
             <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
-            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Tax Preparation</a></li>
-            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll Services</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
             <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
           </ul>
         </div>
@@ -304,6 +307,7 @@
           <ul class="space-y-2 text-blue-200">
             <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
             <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
           </ul>
         </div>
       </div>

--- a/blogs/llc-s-corp-c-corp-california.html
+++ b/blogs/llc-s-corp-c-corp-california.html
@@ -376,7 +376,7 @@
       <div class="grid md:grid-cols-4 gap-8">
         <div>
           <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200 mb-4">Professional financial services for small businesses and individuals in California.</p>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
           <div class="flex space-x-4">
             <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
             <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
@@ -386,9 +386,12 @@
         <div>
           <h3 class="font-bold text-lg mb-4">Services</h3>
           <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
             <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
-            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Tax Preparation</a></li>
-            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll Services</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
             <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
           </ul>
         </div>
@@ -408,6 +411,7 @@
           <ul class="space-y-2 text-blue-200">
             <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
             <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
           </ul>
         </div>
       </div>

--- a/blogs/payroll-compliance-checklist-california.html
+++ b/blogs/payroll-compliance-checklist-california.html
@@ -310,7 +310,7 @@
       <div class="grid md:grid-cols-4 gap-8">
         <div>
           <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200 mb-4">Professional financial services for small businesses and individuals in California.</p>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
           <div class="flex space-x-4">
             <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
             <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
@@ -320,9 +320,12 @@
         <div>
           <h3 class="font-bold text-lg mb-4">Services</h3>
           <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
             <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
-            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Tax Preparation</a></li>
-            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll Services</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
             <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
           </ul>
         </div>
@@ -342,6 +345,7 @@
           <ul class="space-y-2 text-blue-200">
             <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
             <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
           </ul>
         </div>
       </div>

--- a/blogs/rsus-stock-sales-explained.html
+++ b/blogs/rsus-stock-sales-explained.html
@@ -587,7 +587,7 @@
       <div class="grid md:grid-cols-4 gap-8">
         <div>
           <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200 mb-4">Professional financial services for small businesses and individuals in California.</p>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
           <div class="flex space-x-4">
             <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
             <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
@@ -597,9 +597,12 @@
         <div>
           <h3 class="font-bold text-lg mb-4">Services</h3>
           <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
             <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
-            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Tax Preparation</a></li>
-            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll Services</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
             <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
           </ul>
         </div>
@@ -619,6 +622,7 @@
           <ul class="space-y-2 text-blue-200">
             <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
             <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
           </ul>
         </div>
       </div>

--- a/blogs/startup-tax-deductions.html
+++ b/blogs/startup-tax-deductions.html
@@ -468,7 +468,7 @@
       <div class="grid md:grid-cols-4 gap-8">
         <div>
           <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200 mb-4">Professional financial services for small businesses in the Bay Area.</p>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
           <div class="flex space-x-4">
             <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
             <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
@@ -478,9 +478,12 @@
         <div>
           <h3 class="font-bold text-lg mb-4">Services</h3>
           <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
             <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
-            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Tax Preparation</a></li>
-            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll Services</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
             <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
           </ul>
         </div>
@@ -500,6 +503,7 @@
           <ul class="space-y-2 text-blue-200">
             <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
             <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
           </ul>
         </div>
       </div>

--- a/blogs/top-tax-credits-california-families.html
+++ b/blogs/top-tax-credits-california-families.html
@@ -274,7 +274,7 @@
       <div class="grid md:grid-cols-4 gap-8">
         <div>
           <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200 mb-4">Professional financial services for small businesses and individuals in California.</p>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
           <div class="flex space-x-4">
             <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
             <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
@@ -284,9 +284,12 @@
         <div>
           <h3 class="font-bold text-lg mb-4">Services</h3>
           <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
             <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
-            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Tax Preparation</a></li>
-            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll Services</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
             <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
           </ul>
         </div>
@@ -306,6 +309,7 @@
           <ul class="space-y-2 text-blue-200">
             <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
             <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
           </ul>
         </div>
       </div>

--- a/blogs/w4-de4-withholding-guide-california.html
+++ b/blogs/w4-de4-withholding-guide-california.html
@@ -492,7 +492,7 @@
       <div class="grid md:grid-cols-4 gap-8">
         <div>
           <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200 mb-4">Professional financial services for small businesses and individuals in California.</p>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
           <div class="flex space-x-4">
             <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
             <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
@@ -502,9 +502,12 @@
         <div>
           <h3 class="font-bold text-lg mb-4">Services</h3>
           <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
             <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
-            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Tax Preparation</a></li>
-            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll Services</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
             <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
           </ul>
         </div>
@@ -524,6 +527,7 @@
           <ul class="space-y-2 text-blue-200">
             <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
             <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
           </ul>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -837,6 +837,10 @@
                             <i class="fas fa-envelope mt-1 mr-2 text-sm"></i>
                             <span>info@bloomingfinancials.com</span>
                         </li>
+                        <li class="flex items-start">
+                            <i class="fas fa-clock mt-1 mr-2 text-sm"></i>
+                            <span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -241,7 +241,7 @@
       <div class="grid md:grid-cols-3 gap-8">
         <div>
           <div class="text-2xl font-bold mb-3"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200">Professional financial services for individuals and small businesses in the Bay Area.</p>
+          <p class="text-blue-200">Professional financial services for individuals and small businesses in California.</p>
         </div>
         <div>
           <h3 class="font-bold text-lg mb-3">Legal</h3>

--- a/terms/index.html
+++ b/terms/index.html
@@ -208,7 +208,7 @@
       <div class="grid md:grid-cols-3 gap-8">
         <div>
           <div class="text-2xl font-bold mb-3"><span class="text-blue-400">Blooming</span> Financial</div>
-          <p class="text-blue-200">Professional financial services for individuals and small businesses in the Bay Area.</p>
+          <p class="text-blue-200">Professional financial services for individuals and small businesses in California.</p>
         </div>
         <div>
           <h3 class="font-bold text-lg mb-3">Legal</h3>


### PR DESCRIPTION
The footers had drifted into four variants: stale "Bay Area" copy on the blogs hub, blog articles, and privacy/terms; a 4-item Services list on the blogs hub and every blog article; and a missing hours line on the homepage and blogs hub.

Now every page-with-a-full-footer (homepage, services hub, all 7 service detail pages, blogs hub, all 7 blog articles) shows:
- The same tagline: "Professional financial services for individuals and small businesses in California."
- The same 7-item Services column (Individual Tax Prep, Business Tax Prep, Tax Planning, Bookkeeping, Payroll, IRS & FTB Notice Support, Business Consulting).
- The same Contact column with phone, email, and hours.

Privacy and Terms keep their lightweight 3-column footer (cookie preferences, no Services or social block) but pick up the canonical tagline so the brand description matches everywhere.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf