### PR TITLE
Center bottom row of homepage service cards; drop redundant subtitle

### DIFF
--- a/index.html
+++ b/index.html
@@ -310,7 +310,7 @@
                 </div>
 
                 <!-- Payroll Card -->
-                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300">
+                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300 lg:col-start-2">
                     <div class="text-blue-600 mb-4">
                         <i class="fas fa-money-check-alt text-4xl"></i>
                     </div>
@@ -371,7 +371,6 @@
                     View all services
                     <i class="fas fa-arrow-right ml-2"></i>
                 </a>
-                <p class="text-gray-600 mt-3 text-sm">Including individual &amp; business tax preparation, tax planning, and IRS &amp; FTB notice support.</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
At lg, the 5-card grid wrapped as 3+2 with the bottom two left-aligned, which looked unbalanced. Add lg:col-start-2 to the Payroll card so the bottom row starts in column 2 and the two cards (Payroll, Consulting) center under the three above. md (2-col) layout is unchanged.

Also remove the "Including individual & business tax preparation, tax planning, and IRS & FTB notice support." subtitle below the View All Services CTA — the dropdown nav now exposes those service names directly, so the subtitle is redundant.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf