### PR TITLE
Truly center bottom row of homepage service cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -224,9 +224,9 @@
                 <p class="text-xl text-gray-600 max-w-2xl mx-auto">Comprehensive financial solutions designed to meet your business and personal financial needs</p>
             </div>
             
-            <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+            <div class="grid md:grid-cols-2 lg:grid-cols-6 gap-8">
                 <!-- Individual Tax Preparation Card -->
-                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300">
+                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300 lg:col-span-2">
                     <div class="text-blue-600 mb-4">
                         <i class="fas fa-user text-4xl"></i>
                     </div>
@@ -254,7 +254,7 @@
                 </div>
 
                 <!-- Business Tax Preparation Card -->
-                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300">
+                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300 lg:col-span-2">
                     <div class="text-blue-600 mb-4">
                         <i class="fas fa-briefcase text-4xl"></i>
                     </div>
@@ -282,7 +282,7 @@
                 </div>
 
                 <!-- Bookkeeping Card -->
-                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300">
+                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300 lg:col-span-2">
                     <div class="text-blue-600 mb-4">
                         <i class="fas fa-calculator text-4xl"></i>
                     </div>
@@ -310,7 +310,7 @@
                 </div>
 
                 <!-- Payroll Card -->
-                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300 lg:col-start-2">
+                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300 lg:col-span-2 lg:col-start-2">
                     <div class="text-blue-600 mb-4">
                         <i class="fas fa-money-check-alt text-4xl"></i>
                     </div>
@@ -338,7 +338,7 @@
                 </div>
 
                 <!-- Consulting Card -->
-                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300">
+                <div class="service-card bg-white rounded-lg shadow-md p-8 transition duration-300 lg:col-span-2">
                     <div class="text-blue-600 mb-4">
                         <i class="fas fa-chart-line text-4xl"></i>
                     </div>


### PR DESCRIPTION
Previous attempt used lg:col-start-2 on a 3-column grid, which only shifted the bottom row one column right (cols 2-3) — right-aligned, not centered.

Switch the lg grid to 6 columns with each card spanning 2. Top row fills cols 1-2, 3-4, 5-6. Bottom row offsets the Payroll card to col-start-2 so the pair lands at cols 2-3 and 4-5, with col 1 and col 6 empty — centered under the three cards above. md (2-col) layout is unchanged.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf