### PR TITLE
Testimonial carousel: infinite loop, drag-to-scroll, mobile arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,17 +417,17 @@
                 <p class="text-xl text-gray-600 max-w-2xl mx-auto">Don't just take our word for it - hear from our satisfied clients</p>
             </div>
 
-            <div class="relative" data-testimonial-carousel>
-                <button type="button" data-testimonial-prev aria-label="Previous testimonials" class="hidden md:flex absolute left-0 top-1/2 -translate-y-1/2 -translate-x-2 lg:-translate-x-4 z-10 w-12 h-12 items-center justify-center bg-white shadow-lg rounded-full text-blue-600 hover:bg-blue-50 transition">
+            <div class="relative px-10 sm:px-12 md:px-14 lg:px-16" data-testimonial-carousel>
+                <button type="button" data-testimonial-prev aria-label="Previous testimonials" class="flex absolute left-0 top-1/2 -translate-y-1/2 z-10 w-12 h-12 items-center justify-center bg-white shadow-lg rounded-full text-blue-600 hover:bg-blue-50 transition">
                     <i class="fas fa-chevron-left"></i>
                 </button>
-                <button type="button" data-testimonial-next aria-label="Next testimonials" class="hidden md:flex absolute right-0 top-1/2 -translate-y-1/2 translate-x-2 lg:translate-x-4 z-10 w-12 h-12 items-center justify-center bg-white shadow-lg rounded-full text-blue-600 hover:bg-blue-50 transition">
+                <button type="button" data-testimonial-next aria-label="Next testimonials" class="flex absolute right-0 top-1/2 -translate-y-1/2 z-10 w-12 h-12 items-center justify-center bg-white shadow-lg rounded-full text-blue-600 hover:bg-blue-50 transition">
                     <i class="fas fa-chevron-right"></i>
                 </button>
 
-                <div data-testimonial-track class="testimonial-track flex gap-6 overflow-x-auto snap-x snap-mandatory pb-4 scroll-smooth">
+                <div data-testimonial-track class="testimonial-track flex gap-6 overflow-x-auto snap-x snap-mandatory pb-4 cursor-grab select-none">
                     <!-- 1. Mahmoud T. -->
-                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-full md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
+                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-[88%] md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
                         <div class="flex items-center mb-4">
                             <div class="text-yellow-400">
                                 <i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i>
@@ -441,7 +441,7 @@
                     </div>
 
                     <!-- 2. Sahara T. -->
-                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-full md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
+                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-[88%] md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
                         <div class="flex items-center mb-4">
                             <div class="text-yellow-400">
                                 <i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i>
@@ -455,7 +455,7 @@
                     </div>
 
                     <!-- 3. Crystal M. -->
-                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-full md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
+                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-[88%] md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
                         <div class="flex items-center mb-4">
                             <div class="text-yellow-400">
                                 <i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i>
@@ -469,7 +469,7 @@
                     </div>
 
                     <!-- 4. Evan Sandrasagara -->
-                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-full md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
+                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-[88%] md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
                         <div class="flex items-center mb-4">
                             <div class="text-yellow-400">
                                 <i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i>
@@ -483,7 +483,7 @@
                     </div>
 
                     <!-- 5. Silas Salis -->
-                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-full md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
+                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-[88%] md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
                         <div class="flex items-center mb-4">
                             <div class="text-yellow-400">
                                 <i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i>
@@ -497,7 +497,7 @@
                     </div>
 
                     <!-- 6. Victor L. -->
-                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-full md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
+                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-[88%] md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
                         <div class="flex items-center mb-4">
                             <div class="text-yellow-400">
                                 <i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i>
@@ -511,7 +511,7 @@
                     </div>
 
                     <!-- 7. Sally T. -->
-                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-full md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
+                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-[88%] md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
                         <div class="flex items-center mb-4">
                             <div class="text-yellow-400">
                                 <i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i>
@@ -525,7 +525,7 @@
                     </div>
 
                     <!-- 8. S L -->
-                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-full md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
+                    <div class="testimonial-card flex flex-col flex-shrink-0 snap-start w-[88%] md:w-[calc((100%-1.5rem)/2)] lg:w-[calc((100%-3rem)/3)] bg-gray-50 p-8 rounded-lg">
                         <div class="flex items-center mb-4">
                             <div class="text-yellow-400">
                                 <i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i><i class="fas fa-star"></i>
@@ -1056,20 +1056,81 @@
             });
         });
 
-        // Testimonial carousel
+        // Testimonial carousel: clone for infinite loop, arrow buttons, mouse drag-to-scroll.
         document.querySelectorAll('[data-testimonial-carousel]').forEach(carousel => {
             const track = carousel.querySelector('[data-testimonial-track]');
             const prev  = carousel.querySelector('[data-testimonial-prev]');
             const next  = carousel.querySelector('[data-testimonial-next]');
             if (!track) return;
+
+            // Snapshot originals before cloning so clones don't beget clones.
+            const originals = Array.from(track.children);
+            const gapPx = () => parseInt(getComputedStyle(track).columnGap) || 24;
+            const setWidth = () => originals.reduce((sum, c) => sum + c.offsetWidth + gapPx(), 0);
+
+            // Clone the original set once before and once after for seamless looping.
+            const buildClones = () => {
+                const frag = document.createDocumentFragment();
+                originals.forEach(card => {
+                    const c = card.cloneNode(true);
+                    c.setAttribute('aria-hidden', 'true');
+                    c.setAttribute('data-clone', 'true');
+                    frag.appendChild(c);
+                });
+                return frag;
+            };
+            track.insertBefore(buildClones(), track.firstChild);
+            track.appendChild(buildClones());
+
+            // Position user at the start of the originals (after the prepended clones).
+            requestAnimationFrame(() => { track.scrollLeft = setWidth(); });
+
+            // Teleport across clone boundaries to fake infinite scroll.
+            let ticking = false;
+            track.addEventListener('scroll', () => {
+                if (ticking) return;
+                ticking = true;
+                requestAnimationFrame(() => {
+                    ticking = false;
+                    const w = setWidth();
+                    const sl = track.scrollLeft;
+                    if (sl < w) { track.scrollLeft = sl + w; }
+                    else if (sl >= w * 2) { track.scrollLeft = sl - w; }
+                });
+            });
+
+            // Arrow buttons advance by one card width.
             const scrollByOne = (dir) => {
-                const card = track.firstElementChild;
+                const card = originals[0];
                 if (!card) return;
-                const gap = parseInt(getComputedStyle(track).columnGap) || 24;
-                track.scrollBy({ left: (card.offsetWidth + gap) * dir, behavior: 'smooth' });
+                track.scrollBy({ left: (card.offsetWidth + gapPx()) * dir, behavior: 'smooth' });
             };
             prev?.addEventListener('click', () => scrollByOne(-1));
             next?.addEventListener('click', () => scrollByOne(1));
+
+            // Mouse drag-to-scroll. 5px threshold so simple clicks still select text inside cards.
+            let isDown = false, startX = 0, startScroll = 0, dragged = false;
+            const DRAG_THRESHOLD = 5;
+            track.addEventListener('mousedown', e => {
+                isDown = true; dragged = false;
+                startX = e.pageX; startScroll = track.scrollLeft;
+            });
+            track.addEventListener('mousemove', e => {
+                if (!isDown) return;
+                const delta = e.pageX - startX;
+                if (!dragged && Math.abs(delta) < DRAG_THRESHOLD) return;
+                dragged = true;
+                track.classList.add('cursor-grabbing');
+                e.preventDefault();
+                track.scrollLeft = startScroll - delta * 1.5;
+            });
+            const endDrag = () => { isDown = false; track.classList.remove('cursor-grabbing'); };
+            track.addEventListener('mouseup', endDrag);
+            track.addEventListener('mouseleave', endDrag);
+            // Suppress click events that follow a drag (capture phase) so card text doesn't get accidentally selected/clicked.
+            track.addEventListener('click', e => {
+                if (dragged) { e.preventDefault(); e.stopPropagation(); dragged = false; }
+            }, true);
         });
 
         // FAQ toggle functionality


### PR DESCRIPTION
Four changes to the homepage testimonial carousel based on user feedback after seeing it live:

1. Infinite loop. Clone the 8 originals once before and once after the track (24 total slots, clones marked aria-hidden + data-clone). Start scrollLeft at the boundary of the originals; on every scroll, if the user has crossed into a clone region, instantly teleport scrollLeft by the width of one set so they're now at the equivalent position in the originals. Visually seamless because the clone byte-identical to the card they teleport onto.

2. Mouse drag-to-scroll on desktop. mousedown/mousemove/mouseup update scrollLeft 1.5x the cursor delta. 5px threshold so simple clicks inside cards still select text normally. A capture-phase click suppressor prevents the synthetic click that follows a drag from firing anything else.

3. Arrows visible on mobile. Drop the hidden md:flex on both chevron buttons. On a 375px viewport, visitors now have an explicit cue that more reviews exist (plus the new peeking card from change 4).

4. Arrows no longer overlap cards. Wrap the track in px-10 sm:px-12 md:px-14 lg:px-16, then position arrows at left-0 / right-0 of the wrapper so they live in the reserved padding outside the cards. Also change mobile card width from w-full to w-[88%] so ~12% of the next card peeks in from the right edge — another discoverability cue.

Skipped on purpose: auto-advance (a11y anti-pattern; fights reduced- motion), dot indicators (clutter at 8 cards), 3-cards-per-view on mobile (would leave each card ~109px wide; too narrow to read 40-110 word quotes). Stuck to vanilla JS to honor DESIGN.md's no-framework rule.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf