### PR TITLE
Use Google “G” logo for reviews and add Google CTA styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,22 @@
         .testimonial-track { scrollbar-width: none; }
         #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
         #mobileMenu:not(.invisible) { transition-delay: 0s; }
-    body.mobile-menu-open { overflow: hidden; }
+        body.mobile-menu-open { overflow: hidden; }
+        .google-g-icon {
+            width: 1em;
+            height: 1em;
+            display: inline-block;
+            vertical-align: -0.12em;
+            margin-right: 0.25rem;
+        }
+        .google-cta {
+            background-color: #ffffff;
+            color: #1f2937;
+            border: 1px solid #dadce0;
+        }
+        .google-cta:hover {
+            background-color: #f8f9fa;
+        }
     </style>
 </head>
     
@@ -478,7 +493,7 @@
                         <p class="text-gray-700 mb-6 flex-grow">"Working with Ajlin was a great experience. She was highly responsive, engaged throughout the process, and incredibly easy to work with. They handled my return with diligence and speed without sacrificing attention to detail."</p>
                         <div>
                             <h4 class="font-bold text-blue-900">Evan S.</h4>
-                            <p class="text-gray-600 text-sm flex items-center flex-wrap"><span>Individual Tax Client, Lathrop, CA</span><span class="mx-2 text-gray-400">|</span><i class="fab fa-google text-blue-600 mr-1" aria-hidden="true"></i><span>Google Review</span></p>
+                            <p class="text-gray-600 text-sm flex items-center flex-wrap"><span>Individual Tax Client, Lathrop, CA</span><span class="mx-2 text-gray-400">|</span><img src="https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png" alt="Google G logo" class="google-g-icon"><span>Google Review</span></p>
                         </div>
                     </div>
 
@@ -492,7 +507,7 @@
                         <p class="text-gray-700 mb-6 flex-grow">"Ajlin was very helpful during this stressful time. She took the time to explain everything to me and thoroughly answer any questions that I had during the process. I will be going back to Ajlin for next year's tax season."</p>
                         <div>
                             <h4 class="font-bold text-blue-900">Silas S.</h4>
-                            <p class="text-gray-600 text-sm flex items-center flex-wrap"><span>Individual Tax Client, Fairfield, CA</span><span class="mx-2 text-gray-400">|</span><i class="fab fa-google text-blue-600 mr-1" aria-hidden="true"></i><span>Google Review</span></p>
+                            <p class="text-gray-600 text-sm flex items-center flex-wrap"><span>Individual Tax Client, Fairfield, CA</span><span class="mx-2 text-gray-400">|</span><img src="https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png" alt="Google G logo" class="google-g-icon"><span>Google Review</span></p>
                         </div>
                     </div>
 
@@ -534,7 +549,7 @@
                         <p class="text-gray-700 mb-6 flex-grow">"I found Blooming Financial recently and decided to give them a shot. I was looking for a bookkeeper as a new business owner, and I'm really glad I did. They've been easy to work with, organized, patient, and genuinely care about getting things right."</p>
                         <div>
                             <h4 class="font-bold text-blue-900">S. L.</h4>
-                            <p class="text-gray-600 text-sm flex items-center flex-wrap"><span>Business Owner, San Francisco, CA</span><span class="mx-2 text-gray-400">|</span><i class="fab fa-google text-blue-600 mr-1" aria-hidden="true"></i><span>Google Review</span></p>
+                            <p class="text-gray-600 text-sm flex items-center flex-wrap"><span>Business Owner, San Francisco, CA</span><span class="mx-2 text-gray-400">|</span><img src="https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png" alt="Google G logo" class="google-g-icon"><span>Google Review</span></p>
                         </div>
                     </div>
                 </div>
@@ -545,8 +560,8 @@
                     <i class="fab fa-yelp text-xl mr-2"></i>
                     Read More on Yelp
                 </a>
-                <a href="https://maps.app.goo.gl/M9mnPVoVzsPRMNb89" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center bg-gray-900 text-white px-6 py-3 rounded-md hover:bg-gray-800 transition">
-                    <i class="fab fa-google text-xl mr-2"></i>
+                <a href="https://maps.app.goo.gl/M9mnPVoVzsPRMNb89" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center google-cta px-6 py-3 rounded-md transition">
+                    <img src="https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png" alt="Google G logo" class="google-g-icon">
                     Read More on Google
                 </a>
             </div>


### PR DESCRIPTION
### Motivation
- Improve brand consistency by replacing Font Awesome Google icons with the official Google "G" mark in testimonials and the Google CTA button.
- Add lightweight styling for the Google icon and a dedicated CTA style to better match Google's visual treatment.

### Description
- Added `.google-g-icon` and `.google-cta` CSS rules to the page stylesheet to size and style the inline Google logo and CTA button, including a hover state.
- Replaced occurrences of `<i class="fab fa-google ...">` with an inline `<img src="https://www.gstatic.com/images/branding/product/1x/googleg_16dp.png" ...>` in multiple testimonial blocks and the site CTA button.
- Converted the previous dark-gray Google CTA button to use the new `google-cta` class and the inline Google image while keeping link attributes and layout.

### Testing
- Ran `htmlhint` and `stylelint` checks against the modified `index.html` stylesheet and HTML, and both linters passed successfully.
- Performed a basic HTML validation pass (W3C validator) on the changed file and confirmed no new structural errors were introduced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fe6eaa2d48330bb0e936d5e24346e)