### PR TITLE
Fix homepage nav container nesting

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,18 +126,16 @@
                             <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
                         </a>
                         <div data-services-panel class="absolute left-1/2 -translate-x-1/2 top-full pt-2 w-80 hidden z-50">
-                <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
-                    <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
-                    <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
-                    <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
-                    <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
-                    <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
-                    <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
-                    <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
-                </div>
-            </div>
-                </div>
-            </div>
+                            <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
+                                <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
+                                <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
+                                <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
+                                <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
+                                <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
+                                <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
+                                <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
+                            </div>
+                        </div>
                     </div>
                     <a href="#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
                     <a href="#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>


### PR DESCRIPTION
### Motivation
- The desktop navigation layout was broken because the `Services` dropdown wrapper was malformed and closed parent containers early, which disrupted the `md:flex` row for sibling links.
- Restore correct HTML nesting so the dropdown is contained and the remaining nav links render in the intended horizontal layout.

### Description
- Adjusted the HTML structure in `index.html` inside the desktop nav block to properly wrap the `data-services-panel` content and close containers in the correct order.
- Kept all existing classes, links, and attributes unchanged so visual styling and behavior remain intact.
- This change is a pure structural HTML cleanup and does not modify CSS or JavaScript.

### Testing
- Inspected the `index.html` diff to confirm only the navigation markup nesting was modified.
- Verified the affected lines around the desktop navigation (`index.html`) show the `data-services-panel` now contains only the dropdown content.
- Confirmed no other files were changed by this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fef37d9448330bc0efcf24ac41136)