### PR TITLE
Fix Services dropdown markup and indentation in main and blogs pages

### DIFF
--- a/blogs/index.html
+++ b/blogs/index.html
@@ -49,17 +49,15 @@
               <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
             </a>
             <div data-services-panel class="absolute left-1/2 -translate-x-1/2 top-full pt-2 w-80 hidden z-50">
-                <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
-                    <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
-                    <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
-                    <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
-                    <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
-                    <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
-                    <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
-                    <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
-                </div>
-            </div>
-                </div>
+              <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
+                <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
+                <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
+                <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
+                <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
+                <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
+                <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
+                <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
+              </div>
             </div>
           </div>
           <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>

--- a/index.html
+++ b/index.html
@@ -126,18 +126,16 @@
                             <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
                         </a>
                         <div data-services-panel class="absolute left-1/2 -translate-x-1/2 top-full pt-2 w-80 hidden z-50">
-                <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
-                    <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
-                    <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
-                    <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
-                    <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
-                    <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
-                    <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
-                    <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
-                </div>
-            </div>
-                </div>
-            </div>
+                            <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
+                                <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
+                                <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
+                                <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
+                                <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
+                                <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
+                                <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
+                                <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
+                            </div>
+                        </div>
                     </div>
                     <a href="#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
                     <a href="#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>


### PR DESCRIPTION
### Motivation
- Correct malformed/mis-indented markup in the Services dropdown so the desktop panel nests and renders predictably on the site header.

### Description
- Adjusted HTML structure and indentation in `index.html` and `blogs/index.html` to properly nest the `data-services-panel` dropdown content, removed extraneous/misplaced closing tags, and normalized spacing for the services links block.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fef37d9448330bc0efcf24ac41136)