### PR TITLE
Fix JS syntax error breaking Services dropdown on 6 service detail pages

### DIFF
--- a/services/bookkeeping/index.html
+++ b/services/bookkeeping/index.html
@@ -189,6 +189,7 @@
       link.addEventListener('click', () => {
         closeMobileMenu();
       });
+    });
 
 
     const resetMobileServicesMenus = () => {

--- a/services/business-consulting/index.html
+++ b/services/business-consulting/index.html
@@ -184,6 +184,7 @@
       link.addEventListener('click', () => {
         closeMobileMenu();
       });
+    });
 
 
     const resetMobileServicesMenus = () => {

--- a/services/business-tax-preparation/index.html
+++ b/services/business-tax-preparation/index.html
@@ -226,6 +226,7 @@
       link.addEventListener('click', () => {
         closeMobileMenu();
       });
+    });
 
 
     const resetMobileServicesMenus = () => {

--- a/services/irs-ftb-notice-support/index.html
+++ b/services/irs-ftb-notice-support/index.html
@@ -197,6 +197,7 @@
       link.addEventListener('click', () => {
         closeMobileMenu();
       });
+    });
 
 
     const resetMobileServicesMenus = () => {

--- a/services/payroll/index.html
+++ b/services/payroll/index.html
@@ -184,6 +184,7 @@
       link.addEventListener('click', () => {
         closeMobileMenu();
       });
+    });
 
 
     const resetMobileServicesMenus = () => {

--- a/services/tax-planning/index.html
+++ b/services/tax-planning/index.html
@@ -201,6 +201,7 @@
       link.addEventListener('click', () => {
         closeMobileMenu();
       });
+    });
 
 
     const resetMobileServicesMenus = () => {


### PR DESCRIPTION
The mobile-menu link-click handler was missing its closing }); for the .forEach(link => { ... }) callback on 6 of the 7 service detail pages (bookkeeping, business-consulting, business-tax-preparation, irs-ftb-notice-support, payroll, tax-planning). The unclosed arrow function left the rest of the script inside it, ending in "SyntaxError: Unexpected end of input" per node --check. Browsers likewise refuse to execute a script tag that fails to parse, so EVERY handler in that block — mobile menu toggle, mobile services accordion, AND the desktop Services dropdown — silently did nothing on those 6 pages.

The two service pages that worked (services/ hub and services/individual-tax-preparation/) had the closing }); in place; they were probably authored or last-touched in a separate batch.

Add the missing }); after the inner click handler's }); on the 6 affected pages so the forEach callback closes correctly. After the fix, all 39 inline <script> blocks across the site pass node --check.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf