### PR TITLE
Make homepage logo clickable like every other page

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,9 +114,9 @@
         <div class="container mx-auto px-6 py-3">
             <div class="flex items-center justify-between">
                 <div class="flex items-center">
-                    <div class="text-2xl font-bold text-blue-900">
+                    <a href="/" class="text-2xl font-bold text-blue-900">
                         <span class="text-blue-600">Blooming</span> Financial
-                    </div>
+                    </a>
                 </div>
                 <div class="hidden md:flex items-center space-x-8">
                     <a href="#home" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>


### PR DESCRIPTION
The "Blooming Financial" logo in the top-left was a <div> on the homepage but an <a href="/"> on every other page. That meant clicking the logo from the homepage did nothing, while clicking it from anywhere else navigated home. Use the same <a href="/"> on the homepage so clicking the logo always behaves consistently — from the homepage itself, it reloads the page and scrolls to the top.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf