### PR TITLE
Override Tailwind container to scale continuously, not in steps

### DIFF
--- a/blogs/2025-tax-law-changes.html
+++ b/blogs/2025-tax-law-changes.html
@@ -44,6 +44,11 @@
     code.inline { background: #f1f5f9; padding: 0.15rem 0.3rem; border-radius: 0.25rem; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -29,6 +29,11 @@
     .nav-link:hover { color: #3b82f6; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 <body class="bg-gray-50">

--- a/blogs/llc-s-corp-c-corp-california.html
+++ b/blogs/llc-s-corp-c-corp-california.html
@@ -42,6 +42,11 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 

--- a/blogs/payroll-compliance-checklist-california.html
+++ b/blogs/payroll-compliance-checklist-california.html
@@ -42,6 +42,11 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 

--- a/blogs/rsus-stock-sales-explained.html
+++ b/blogs/rsus-stock-sales-explained.html
@@ -42,6 +42,11 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 

--- a/blogs/startup-tax-deductions.html
+++ b/blogs/startup-tax-deductions.html
@@ -42,6 +42,11 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 

--- a/blogs/top-tax-credits-california-families.html
+++ b/blogs/top-tax-credits-california-families.html
@@ -42,6 +42,11 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 

--- a/blogs/w4-de4-withholding-guide-california.html
+++ b/blogs/w4-de4-withholding-guide-california.html
@@ -42,6 +42,11 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -105,6 +105,11 @@
             background-color: #f8f9fa;
             border-color: #c6c6c6;
         }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
     </style>
 </head>
     

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -30,6 +30,11 @@
     .slider:before { position: absolute; content: ""; height: 20px; width: 20px; left: 3px; bottom: 3px; background-color: white; transition: .2s; border-radius: 9999px; }
     input:checked + .slider { background-color: #3b82f6; }
     input:checked + .slider:before { transform: translateX(20px); }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 <body class="bg-gray-50">

--- a/services/bookkeeping/index.html
+++ b/services/bookkeeping/index.html
@@ -36,6 +36,11 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 
   <script type="application/ld+json">

--- a/services/business-consulting/index.html
+++ b/services/business-consulting/index.html
@@ -36,6 +36,11 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 
   <script type="application/ld+json">

--- a/services/business-tax-preparation/index.html
+++ b/services/business-tax-preparation/index.html
@@ -36,6 +36,11 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 
   <script type="application/ld+json">

--- a/services/index.html
+++ b/services/index.html
@@ -43,6 +43,11 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 
   <script type="application/ld+json">

--- a/services/individual-tax-preparation/index.html
+++ b/services/individual-tax-preparation/index.html
@@ -39,6 +39,11 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 
   <script type="application/ld+json">

--- a/services/irs-ftb-notice-support/index.html
+++ b/services/irs-ftb-notice-support/index.html
@@ -36,6 +36,11 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 
   <script type="application/ld+json">

--- a/services/payroll/index.html
+++ b/services/payroll/index.html
@@ -36,6 +36,11 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 
   <script type="application/ld+json">

--- a/services/tax-planning/index.html
+++ b/services/tax-planning/index.html
@@ -36,6 +36,11 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 
   <script type="application/ld+json">

--- a/terms/index.html
+++ b/terms/index.html
@@ -39,6 +39,11 @@
     .slider:before { position: absolute; content: ""; height: 20px; width: 20px; left: 3px; bottom: 3px; background-color: white; transition: .2s; border-radius: 9999px; }
     input:checked + .slider { background-color: #3b82f6; }
     input:checked + .slider:before { transform: translateX(20px); }
+    /* Container override: make .container fill the viewport up to 1536px
+       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
+       selector boosts specificity above Tailwind CDN's injected rules. */
+    .container.container { max-width: 100%; width: 100%; }
+    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
   </style>
 </head>
 <body class="bg-gray-50">


### PR DESCRIPTION
Tailwind's default .container utility caps at discrete max-widths per breakpoint: 1024px at lg, 1280px at xl, 1536px at 2xl. A viewport like 1272px (common on Edge where the sidebar eats ~8px more than Chrome's) falls in the 1024-1279px "dead zone": the container caps at 1024px even though the viewport is 248px wider, leaving big empty side gaps and forcing hero text to wrap more than necessary.

Add a CSS override in each page's inline <style> block that forces .container to fill the viewport up to a single 1536px cap, eliminating the stepped behavior. Above 1536px (4K monitors etc.) the readability cap still applies; below 1024px nothing changes (the base rule is already width: 100%). The visible change is only in the 1024-1535px range — exactly the dead zone where the layout looked broken.

Uses a doubled class selector (.container.container) to win specificity against Tailwind CDN's runtime-injected .container rules, which would otherwise win on source order since they're appended at runtime.

Applied to all 19 HTML files: homepage, services hub, 7 service detail pages, blogs hub, 7 blog articles, privacy, terms.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf