### PR TITLE
Narrow container override to only the 1024-1279.98px dead zone

### DIFF
--- a/blogs/2025-tax-law-changes.html
+++ b/blogs/2025-tax-law-changes.html
@@ -44,11 +44,15 @@
     code.inline { background: #f1f5f9; padding: 0.15rem 0.3rem; border-radius: 0.25rem; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -29,11 +29,15 @@
     .nav-link:hover { color: #3b82f6; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 <body class="bg-gray-50">

--- a/blogs/llc-s-corp-c-corp-california.html
+++ b/blogs/llc-s-corp-c-corp-california.html
@@ -42,11 +42,15 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 

--- a/blogs/payroll-compliance-checklist-california.html
+++ b/blogs/payroll-compliance-checklist-california.html
@@ -42,11 +42,15 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 

--- a/blogs/rsus-stock-sales-explained.html
+++ b/blogs/rsus-stock-sales-explained.html
@@ -42,11 +42,15 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 

--- a/blogs/startup-tax-deductions.html
+++ b/blogs/startup-tax-deductions.html
@@ -42,11 +42,15 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 

--- a/blogs/top-tax-credits-california-families.html
+++ b/blogs/top-tax-credits-california-families.html
@@ -42,11 +42,15 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 

--- a/blogs/w4-de4-withholding-guide-california.html
+++ b/blogs/w4-de4-withholding-guide-california.html
@@ -42,11 +42,15 @@
     .toc a { color: #1d4ed8; }
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 

--- a/index.html
+++ b/index.html
@@ -105,11 +105,15 @@
             background-color: #f8f9fa;
             border-color: #c6c6c6;
         }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
     </style>
 </head>
     

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -30,11 +30,15 @@
     .slider:before { position: absolute; content: ""; height: 20px; width: 20px; left: 3px; bottom: 3px; background-color: white; transition: .2s; border-radius: 9999px; }
     input:checked + .slider { background-color: #3b82f6; }
     input:checked + .slider:before { transform: translateX(20px); }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 <body class="bg-gray-50">

--- a/services/bookkeeping/index.html
+++ b/services/bookkeeping/index.html
@@ -36,11 +36,15 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 
   <script type="application/ld+json">

--- a/services/business-consulting/index.html
+++ b/services/business-consulting/index.html
@@ -36,11 +36,15 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 
   <script type="application/ld+json">

--- a/services/business-tax-preparation/index.html
+++ b/services/business-tax-preparation/index.html
@@ -36,11 +36,15 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 
   <script type="application/ld+json">

--- a/services/index.html
+++ b/services/index.html
@@ -43,11 +43,15 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 
   <script type="application/ld+json">

--- a/services/individual-tax-preparation/index.html
+++ b/services/individual-tax-preparation/index.html
@@ -39,11 +39,15 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 
   <script type="application/ld+json">

--- a/services/irs-ftb-notice-support/index.html
+++ b/services/irs-ftb-notice-support/index.html
@@ -36,11 +36,15 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 
   <script type="application/ld+json">

--- a/services/payroll/index.html
+++ b/services/payroll/index.html
@@ -36,11 +36,15 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 
   <script type="application/ld+json">

--- a/services/tax-planning/index.html
+++ b/services/tax-planning/index.html
@@ -36,11 +36,15 @@
     #mobileMenu { transition: transform 300ms ease-in-out, opacity 300ms ease-in-out, visibility 0s linear 300ms; }
     #mobileMenu:not(.invisible) { transition-delay: 0s; }
     body.mobile-menu-open { overflow: hidden; }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 
   <script type="application/ld+json">

--- a/terms/index.html
+++ b/terms/index.html
@@ -39,11 +39,15 @@
     .slider:before { position: absolute; content: ""; height: 20px; width: 20px; left: 3px; bottom: 3px; background-color: white; transition: .2s; border-radius: 9999px; }
     input:checked + .slider { background-color: #3b82f6; }
     input:checked + .slider:before { transform: translateX(20px); }
-    /* Container override: make .container fill the viewport up to 1536px
-       instead of stepping at Tailwind's lg/xl breakpoints. Doubled class
-       selector boosts specificity above Tailwind CDN's injected rules. */
-    .container.container { max-width: 100%; width: 100%; }
-    @media (min-width: 1536px) { .container.container { max-width: 1536px; } }
+    /* Container override: only the 1024-1279.98px "dead zone" where
+       Tailwind's default caps content at 1024px and leaves wide side gaps.
+       At 1280px+, Tailwind's default 1280px / 1536px caps apply unchanged
+       so the framed look at common Chrome viewport widths is preserved.
+       Doubled selector boosts specificity above Tailwind CDN's runtime-
+       injected .container rules. */
+    @media (min-width: 1024px) and (max-width: 1279.98px) {
+      .container.container { max-width: 100%; }
+    }
   </style>
 </head>
 <body class="bg-gray-50">


### PR DESCRIPTION
Commit 2100107 fixed the Edge dead zone at 1272px but went too far — it also stripped the framed/bordered look at 1280-1535px viewports (where Chrome usually sits), making homepage sections and the blog index stretch end-to-end on screens where they used to have side margins.

Tighten the override so it only applies in the 1024-1279.98px range, which is the actual dead zone. At 1280px+ Tailwind's default container caps (1280 / 1536) come back, restoring the original framed look. At 1024-1279px the override still forces 100% width so the Edge problem stays fixed.

After this commit, behavior at common viewports:
  1024-1279px: content fills viewport (Edge fix preserved)
  1280-1535px: content caps at 1280px, side margins visible (RESTORED)
  1536+:       content caps at 1536px, centered (unchanged)

Same 19 HTML files modified; previous override block replaced in place.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf