### PR TITLE
Add OpenAI Ads (ChatGPT) conversion pixel

### DIFF
--- a/blogs/2025-tax-law-changes.html
+++ b/blogs/2025-tax-law-changes.html
@@ -8,6 +8,11 @@
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');
   </script>
 
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -7,6 +7,11 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');
   </script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Blooming Financial Blog | Insights & Tips for Small Businesses</title>

--- a/blogs/llc-s-corp-c-corp-california.html
+++ b/blogs/llc-s-corp-c-corp-california.html
@@ -7,6 +7,11 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');
   </script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/blogs/payroll-compliance-checklist-california.html
+++ b/blogs/payroll-compliance-checklist-california.html
@@ -7,6 +7,11 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');
   </script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/blogs/rsus-stock-sales-explained.html
+++ b/blogs/rsus-stock-sales-explained.html
@@ -7,6 +7,11 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');
   </script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/blogs/startup-tax-deductions.html
+++ b/blogs/startup-tax-deductions.html
@@ -7,6 +7,11 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');
   </script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/blogs/top-tax-credits-california-families.html
+++ b/blogs/top-tax-credits-california-families.html
@@ -7,6 +7,11 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');
   </script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/blogs/w4-de4-withholding-guide-california.html
+++ b/blogs/w4-de4-withholding-guide-california.html
@@ -7,6 +7,11 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');
   </script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 

--- a/index.html
+++ b/index.html
@@ -10,6 +10,11 @@
     
       gtag('config', 'G-RVPQPZB973');
     </script>
+    <!-- OpenAI Ads (ChatGPT) pixel -->
+    <script>
+    !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+    oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="theme-color" content="#1e3a8a">
@@ -1189,6 +1194,15 @@
                     // Hide form container and show thank you message
                     document.getElementById('contactFormContainer').classList.add('hidden');
                     document.getElementById('contact-thank-you').classList.remove('hidden');
+
+                    // OpenAI Ads (ChatGPT) conversion: contact form submitted
+                    if (window.oaiq) {
+                        oaiq("measure", "registration_completed", {
+                            type: "customer_action",
+                            amount: 0,
+                            currency: "USD"
+                        });
+                    }
                 } else {
                     console.error('Formspree error response', response);
                     alert('There was an error sending your message. Please try again or call us directly.');
@@ -1250,6 +1264,15 @@
                     // Hide the form container and show thank you message
                     document.getElementById('formContainer').classList.add('hidden');
                     document.getElementById('thank-you').classList.remove('hidden');
+
+                    // OpenAI Ads (ChatGPT) conversion: consultation form submitted
+                    if (window.oaiq) {
+                        oaiq("measure", "registration_completed", {
+                            type: "customer_action",
+                            amount: 0,
+                            currency: "USD"
+                        });
+                    }
                 } else {
                     // Handle error
                     console.error('Formspree error response', response);

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -3,6 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <title>Privacy Policy | Blooming Financial</title>
   <meta name="description" content="Blooming Financial privacy policy, cookies and analytics preferences, and California privacy rights." />
   <link rel="canonical" href="https://www.bloomingfinancials.com/privacy/" />

--- a/services/bookkeeping/index.html
+++ b/services/bookkeeping/index.html
@@ -3,6 +3,11 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVPQPZB973"></script>
   <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');</script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#1e3a8a" />

--- a/services/business-consulting/index.html
+++ b/services/business-consulting/index.html
@@ -3,6 +3,11 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVPQPZB973"></script>
   <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');</script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#1e3a8a" />

--- a/services/business-tax-preparation/index.html
+++ b/services/business-tax-preparation/index.html
@@ -3,6 +3,11 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVPQPZB973"></script>
   <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');</script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#1e3a8a" />

--- a/services/index.html
+++ b/services/index.html
@@ -7,6 +7,11 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');
   </script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#1e3a8a" />

--- a/services/individual-tax-preparation/index.html
+++ b/services/individual-tax-preparation/index.html
@@ -3,6 +3,11 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVPQPZB973"></script>
   <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');</script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#1e3a8a" />

--- a/services/irs-ftb-notice-support/index.html
+++ b/services/irs-ftb-notice-support/index.html
@@ -3,6 +3,11 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVPQPZB973"></script>
   <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');</script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#1e3a8a" />

--- a/services/payroll/index.html
+++ b/services/payroll/index.html
@@ -3,6 +3,11 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVPQPZB973"></script>
   <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');</script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#1e3a8a" />

--- a/services/tax-planning/index.html
+++ b/services/tax-planning/index.html
@@ -3,6 +3,11 @@
 <head>
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-RVPQPZB973"></script>
   <script>window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config', 'G-RVPQPZB973');</script>
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#1e3a8a" />

--- a/terms/index.html
+++ b/terms/index.html
@@ -3,6 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- OpenAI Ads (ChatGPT) pixel -->
+  <script>
+  !function(w,d,s,u){if(w.oaiq)return;var q=function(){q.q.push(arguments)};q.q=[];w.oaiq=q;var j=d.createElement(s);j.async=1;j.src=u;var f=d.getElementsByTagName(s)[0];f.parentNode.insertBefore(j,f)}(window,document,"script","https://bzrcdn.openai.com/sdk/oaiq.min.js");
+  oaiq("init",{pixelId:"2Hz8qV4vcyHVdviX5VJhAH",debug:false});
+  </script>
   <title>Terms of Service | Blooming Financial</title>
   <meta name="description" content="Blooming Financial Terms of Service for website use, disclaimers, acceptable use, and legal notices." />
   <link rel="canonical" href="https://www.bloomingfinancials.com/terms/" />


### PR DESCRIPTION
Set up conversion tracking for the ChatGPT Ads campaign so Ads Manager can attribute leads (not just clicks) back to the campaign.

Two parts:

1. Base pixel in <head> on all 19 pages, right after the GA tag. Loads OpenAI's oaiq SDK and inits with the Blooming Financial pixel ID. A ChatGPT ad may deep-link to any page (a service detail page, a blog post), so the pixel must be present site-wide for the visitor to be tracked wherever they land. Shipped with debug:false.

2. Conversion event (registration_completed) fired on successful form submission in index.html, for BOTH lead forms:
   - the consultation form (#consultationForm)
   - the contact form (#contactForm) Each fires only inside the response.ok branch, after the thank-you message shows, guarded by `if (window.oaiq)` so a blocked/failed pixel script can't break the form handler.

The event name matches what Ads Manager generated (registration_completed) so the conversion maps correctly. This is independent of GA4, which continues to track overall site traffic.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf