### PR TITLE
Update ChatGPT Ads conversion key to lead_created

### DIFF
--- a/index.html
+++ b/index.html
@@ -1197,10 +1197,8 @@
 
                     // OpenAI Ads (ChatGPT) conversion: contact form submitted
                     if (window.oaiq) {
-                        oaiq("measure", "registration_completed", {
-                            type: "customer_action",
-                            amount: 0,
-                            currency: "USD"
+                        oaiq("measure", "lead_created", {
+                            type: "customer_action"
                         });
                     }
                 } else {
@@ -1267,10 +1265,8 @@
 
                     // OpenAI Ads (ChatGPT) conversion: consultation form submitted
                     if (window.oaiq) {
-                        oaiq("measure", "registration_completed", {
-                            type: "customer_action",
-                            amount: 0,
-                            currency: "USD"
+                        oaiq("measure", "lead_created", {
+                            type: "customer_action"
                         });
                     }
                 } else {


### PR DESCRIPTION
The conversion event was reconfigured in OpenAI Ads Manager:
  Base Event: Lead created
  Conversion name: Consultation Lead
  Conversion window: 30 days

Ads Manager now emits this exact call:
  oaiq("measure", "lead_created", { type: "customer_action" });

Replace both conversion calls (consultation form + contact form success handlers) accordingly:
  - event key registration_completed -> lead_created
  - payload trimmed to { type: "customer_action" } (the amount/currency fields from the generic example are dropped to match the call Ads Manager generated for this event)

Base pixel, site-wide install, debug:false, the window.oaiq guard, and firing only on Formspree response.ok are all unchanged.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf