### PR TITLE
4/4 Single-source nav/footer via partials; add CI checks

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,41 @@
+name: Site checks
+
+# Guards against the failure modes this repo has actually hit:
+# inline-JS syntax errors, broken nav nesting, pages drifting from the
+# shared partials, and a stale committed Tailwind build.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Partials in sync
+        run: python3 tools/build.py --check
+
+      - name: Inline JS syntax + nav nesting
+        run: python3 tools/check.py
+
+      - name: Tailwind build is current
+        run: |
+          npm ci
+          npx tailwindcss -c tailwind.config.js -i tailwind.input.css -o /tmp/tailwind.css --minify
+          if ! diff -q /tmp/tailwind.css assets/tailwind.css; then
+            echo "assets/tailwind.css is stale. Rebuild with:"
+            echo "  npx tailwindcss -c tailwind.config.js -i tailwind.input.css -o assets/tailwind.css --minify"
+            exit 1
+          fi
+          echo "tailwind build current"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -6,7 +6,7 @@ Blooming Financial is a static marketing website for a tax preparation, bookkeep
 
 The repository is the source of truth. Do not invent product names, slogans, services, locations, testimonials, claims, credentials, prices, or features that are not present in the site files.
 
-The repository currently does not contain a package.json, framework configuration, design token file, CLI help text, schemas outside page-level JSON-LD, or a centralized design system. A high-level `README.md` does exist. The website is built from plain HTML files with Tailwind CSS via CDN, Open Sans from Google Fonts, Font Awesome icons, inline CSS, inline JavaScript, static SVG blog images, Formspree forms, and Google Analytics.
+The repository does not contain a frontend framework, design token file, CLI help text, schemas outside page-level JSON-LD, or a centralized design system. A high-level `README.md` documents the light tooling that does exist (a static Tailwind build and shared nav/footer partials). The website is built from plain HTML files with Tailwind CSS compiled to a static stylesheet, Open Sans from Google Fonts, Font Awesome icons, inline CSS, inline JavaScript, static SVG blog images, Formspree forms, and Google Analytics.
 
 ## Current site identity
 
@@ -279,5 +279,7 @@ Keep designs readable and practical.
 ## Implementation notes
 
 The current site is static HTML. A design should be implementable without React, Next, or a large frontend framework. Prefer HTML, Tailwind utility classes, small inline or external JavaScript, and reusable patterns that match the current files.
+
+Tailwind is compiled to a committed static stylesheet (`assets/tailwind.css`); rebuild it after class changes (see README). The nav, mobile menu, and footer on full-nav pages are stamped from `_partials/` by `tools/build.py` — edit the partial, not the page copies.
 
 If the site later migrates to Jekyll or another static-site generator, preserve the same visual identity, URLs, metadata, schema patterns, and service hierarchy.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ Live site: https://www.bloomingfinancials.com/
 
 ## Stack
 
-This is a static GitHub Pages website built with plain HTML, Tailwind CSS from CDN, Open Sans, Font Awesome, static image assets, and small inline JavaScript.
+This is a static GitHub Pages website built with plain HTML, Tailwind CSS (compiled to a static stylesheet), Open Sans, Font Awesome, static image assets, and small inline JavaScript.
 
-There is currently no React, Next.js, Jekyll, package.json, or custom build process. Pages are edited directly as HTML files.
+There is no React, Next.js, or Jekyll. Pages are edited directly as HTML files, with two small build/maintenance steps:
+
+- **Tailwind CSS**: pages link `/assets/tailwind.css`, a committed static build. After adding or changing Tailwind classes, rebuild it with `npx tailwindcss -c tailwind.config.js -i tailwind.input.css -o assets/tailwind.css --minify` (run `npm install` once first).
+- **Shared partials**: the nav, mobile menu, and footer on the 17 full-nav pages are stamped from `_partials/*.html` between `<!-- bf:* -->` sentinel comments. Edit the partial, then run `python3 tools/build.py` to restamp every page. Do not hand-edit inside the sentinels. Privacy and Terms keep their own lightweight header/footer and are not stamped.
+
+CI (`.github/workflows/checks.yml`) fails a PR if the partials are out of sync, the Tailwind build is stale, any inline script has a syntax error, or a nav block has unbalanced divs.
 
 ## Important Files and Folders
 
@@ -69,7 +74,7 @@ The most important design source files are `index.html`, `services/index.html`, 
 
 ## Editing Notes
 
-This site is currently manual HTML. Navigation, footer, styles, scripts, and schema patterns are repeated across multiple files. When making global changes, update every affected page and verify consistency.
+This site is manual HTML with light tooling. The nav, mobile menu, and footer are single-sourced in `_partials/` (see Stack above) — change them there and restamp. Other repeated patterns (head metadata, inline scripts, schema) are still per-page: when changing those globally, update every affected page and verify consistency.
 
 Before publishing SEO-sensitive edits, check:
 

--- a/_partials/footer.html
+++ b/_partials/footer.html
@@ -1,0 +1,53 @@
+<footer class="bg-blue-950 text-white py-12">
+  <div class="container mx-auto px-6">
+    <div class="grid md:grid-cols-4 gap-8">
+      <div>
+        <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
+        <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
+        <div class="flex space-x-4">
+          <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+          <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
+        </div>
+        <p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p>
+      </div>
+      <div>
+        <h3 class="font-bold text-lg mb-4">Services</h3>
+        <ul class="space-y-2">
+          <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+          <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+          <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
+          <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
+          <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+          <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
+          <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="font-bold text-lg mb-4">Quick Links</h3>
+        <ul class="space-y-2">
+          <li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li>
+          <li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li>
+          <li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li>
+          <li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li>
+          <li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li>
+          <li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3 class="font-bold text-lg mb-4">Contact</h3>
+        <ul class="space-y-2 text-blue-200">
+          <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
+          <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+          <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
+        </ul>
+      </div>
+    </div>
+    <div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+      <p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p>
+      <div class="flex space-x-6 text-sm">
+        <a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a>
+        <a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a>
+      </div>
+    </div>
+  </div>
+</footer>

--- a/_partials/mobile-menu.html
+++ b/_partials/mobile-menu.html
@@ -1,0 +1,28 @@
+<div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
+  <div class="flex flex-col space-y-4 p-6">
+    <a href="{{HOME_HREF}}" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+    <div data-mobile-services>
+      <div class="flex items-center justify-between">
+        <a href="/services/" class="{{SERVICES_CLS}}">Services</a>
+        <button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600">
+          <i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i>
+        </button>
+      </div>
+      <div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2">
+        <a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a>
+        <a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a>
+        <a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a>
+        <a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a>
+        <a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a>
+        <a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a>
+        <a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a>
+      </div>
+    </div>
+    <a href="{{ABOUT_HREF}}" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+    <a href="{{TESTIMONIALS_HREF}}" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+    <a href="{{CONTACT_HREF}}" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+    <a href="/blogs/" class="{{BLOGS_CLS}}">Blogs</a>
+    <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+    <a href="{{CONSULTATION_HREF}}" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
+  </div>
+</div>

--- a/_partials/nav.html
+++ b/_partials/nav.html
@@ -1,0 +1,40 @@
+<nav class="bg-white border-0 shadow-none sticky top-0 z-50">
+  <div class="container mx-auto px-6 py-3">
+    <div class="flex items-center justify-between">
+      <div class="flex items-center">
+        <a href="/" class="text-2xl font-bold text-blue-900">
+          <span class="text-blue-600">Blooming</span> Financial
+        </a>
+      </div>
+      <div class="hidden md:flex items-center space-x-8">
+        <a href="{{HOME_HREF}}" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+        <div class="relative" data-services-menu>
+          <a href="/services/" class="{{SERVICES_CLS}} inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+            Services
+            <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
+          </a>
+          <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
+              <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
+                  <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
+                  <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
+                  <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
+                  <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
+                  <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
+                  <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
+                  <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
+              </div>
+          </div>
+        </div>
+        <a href="{{ABOUT_HREF}}" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+        <a href="{{TESTIMONIALS_HREF}}" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+        <a href="{{CONTACT_HREF}}" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+        <a href="/blogs/" class="{{BLOGS_CLS}}">Blogs</a>
+        <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+        <a href="{{CONSULTATION_HREF}}" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
+      </div>
+      <div class="md:hidden">
+        <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/blogs/2025-tax-law-changes.html
+++ b/blogs/2025-tax-law-changes.html
@@ -55,6 +55,7 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- NAVIGATION -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
@@ -95,8 +96,10 @@
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
 
   <!-- Mobile Menu -->
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -125,6 +128,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- HERO -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -537,6 +541,7 @@
   </aside>
 
   <!-- FOOTER -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -590,6 +595,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <!-- Back to Top Button -->
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>

--- a/blogs/index.html
+++ b/blogs/index.html
@@ -50,6 +50,7 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- ================= NAVIGATION ================= -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
@@ -58,7 +59,6 @@
             <span class="text-blue-600">Blooming</span> Financial
           </a>
         </div>
-        <!-- Desktop -->
         <div class="hidden md:flex items-center space-x-8">
           <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
           <div class="relative" data-services-menu>
@@ -67,15 +67,15 @@
               <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
             </a>
             <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
-              <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
-                <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
-                <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
-                <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
-                <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
-                <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
-                <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
-                <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
-              </div>
+                <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
+                    <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
+                    <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
+                    <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
+                    <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
+                    <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
+                    <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
+                    <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
+                </div>
             </div>
           </div>
           <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
@@ -85,14 +85,15 @@
           <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
-        <!-- Mobile -->
         <div class="md:hidden">
           <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
         </div>
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
   <!-- Mobile Panel -->
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -121,6 +122,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- ================= HERO ================= -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -317,6 +319,7 @@
   </section>
 
   <!-- ================= FOOTER ================= -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -370,6 +373,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <!-- Back to Top Button -->
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>

--- a/blogs/llc-s-corp-c-corp-california.html
+++ b/blogs/llc-s-corp-c-corp-california.html
@@ -53,6 +53,7 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- NAVIGATION -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
@@ -93,8 +94,10 @@
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
 
   <!-- Mobile Menu -->
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -123,6 +126,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- HERO -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -409,6 +413,7 @@
   </aside>
 
   <!-- FOOTER -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -462,6 +467,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <!-- Back to Top Button -->
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>

--- a/blogs/payroll-compliance-checklist-california.html
+++ b/blogs/payroll-compliance-checklist-california.html
@@ -53,6 +53,7 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- NAVIGATION -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
@@ -93,8 +94,10 @@
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
 
   <!-- Mobile Menu -->
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -123,6 +126,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- HERO -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -343,6 +347,7 @@
   </aside>
 
   <!-- FOOTER -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -396,6 +401,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <!-- Back to Top Button -->
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>

--- a/blogs/rsus-stock-sales-explained.html
+++ b/blogs/rsus-stock-sales-explained.html
@@ -53,6 +53,7 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- NAVIGATION -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
@@ -93,8 +94,10 @@
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
 
   <!-- Mobile Menu -->
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -123,6 +126,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- HERO -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -620,6 +624,7 @@
   </aside>
 
   <!-- FOOTER -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -673,6 +678,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <!-- Back to Top Button -->
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>

--- a/blogs/startup-tax-deductions.html
+++ b/blogs/startup-tax-deductions.html
@@ -53,6 +53,7 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- NAVIGATION -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
@@ -93,8 +94,10 @@
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
 
   <!-- Mobile Menu -->
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -123,6 +126,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- HERO -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -501,6 +505,7 @@
   </aside>
 
   <!-- FOOTER -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -554,6 +559,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <!-- Back to Top Button -->
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>

--- a/blogs/top-tax-credits-california-families.html
+++ b/blogs/top-tax-credits-california-families.html
@@ -53,6 +53,7 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- NAVIGATION -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
@@ -93,8 +94,10 @@
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
 
   <!-- Mobile Menu -->
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -123,6 +126,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- HERO -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -307,6 +311,7 @@
   </aside>
 
   <!-- FOOTER -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -360,6 +365,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <!-- Back to Top Button -->
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>

--- a/blogs/w4-de4-withholding-guide-california.html
+++ b/blogs/w4-de4-withholding-guide-california.html
@@ -53,6 +53,7 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- NAVIGATION -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
@@ -93,8 +94,10 @@
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
 
   <!-- Mobile Menu -->
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -123,6 +126,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- HERO -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -525,6 +529,7 @@
   </aside>
 
   <!-- FOOTER -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -578,6 +583,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <!-- Back to Top Button -->
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>

--- a/index.html
+++ b/index.html
@@ -127,84 +127,80 @@
 <body class="bg-gray-50">
     <a href="#home" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
     <!-- Navigation -->
+    <!-- bf:nav -->
     <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
-        <div class="container mx-auto px-6 py-3">
-            <div class="flex items-center justify-between">
-                <div class="flex items-center">
-                    <a href="/" class="text-2xl font-bold text-blue-900">
-                        <span class="text-blue-600">Blooming</span> Financial
-                    </a>
-                </div>
-                <div class="hidden md:flex items-center space-x-8">
-                    <a href="#home" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
-                    <div class="relative" data-services-menu>
-                        <a href="/services/" class="nav-link text-gray-700 hover:text-blue-600 transition inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
-                            Services
-                            <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
-                        </a>
-                        <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
-                            <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
-                                <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
-                                <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
-                                <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
-                                <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
-                                <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
-                                <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
-                                <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
-                            </div>
-                        </div>
-                    </div>
-                    <a href="#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
-                    <a href="#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
-                    <a href="#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
-                    <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
-                    <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
-                    <a href="#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
-                </div>
-                <div class="md:hidden">
-                    <button class="text-gray-700 focus:outline-none">
-                        <i class="fas fa-bars text-2xl"></i>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </nav>
-
-    <!-- Mobile Menu (clean dropdown below navbar) -->
-    <div id="mobileMenu"
-     class="fixed inset-x-0 top-14
-            w-full bg-white
-            transform -translate-y-full opacity-0 invisible pointer-events-none
-            transition-all duration-300 ease-in-out
-            z-40 md:hidden"
-     aria-hidden="true">
-        <div class="flex flex-col space-y-4 p-6">
+      <div class="container mx-auto px-6 py-3">
+        <div class="flex items-center justify-between">
+          <div class="flex items-center">
+            <a href="/" class="text-2xl font-bold text-blue-900">
+              <span class="text-blue-600">Blooming</span> Financial
+            </a>
+          </div>
+          <div class="hidden md:flex items-center space-x-8">
             <a href="#home" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
-            <div data-mobile-services>
-                <div class="flex items-center justify-between">
-                    <a href="/services/" class="nav-link text-gray-700 hover:text-blue-600 transition">Services</a>
-                    <button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600">
-                        <i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i>
-                    </button>
-                </div>
-                <div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2">
-                    <a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a>
-                    <a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a>
-                    <a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a>
-                    <a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a>
-                    <a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a>
-                    <a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a>
-                    <a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a>
-                </div>
+            <div class="relative" data-services-menu>
+              <a href="/services/" class="nav-link text-gray-700 hover:text-blue-600 transition inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+                Services
+                <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
+              </a>
+              <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
+                  <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
+                      <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
+                      <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
+                      <a href="/services/tax-planning/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Tax Planning</a>
+                      <a href="/services/bookkeeping/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Bookkeeping</a>
+                      <a href="/services/payroll/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Payroll</a>
+                      <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
+                      <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
+                  </div>
+              </div>
             </div>
             <a href="#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
             <a href="#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
             <a href="#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
             <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
             <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
-            <a href="#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
+            <a href="#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
+          </div>
+          <div class="md:hidden">
+            <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
+          </div>
         </div>
+      </div>
+    </nav>
+    <!-- /bf:nav -->
+
+    <!-- Mobile Menu (clean dropdown below navbar) -->
+    <!-- bf:mobile-menu -->
+    <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
+      <div class="flex flex-col space-y-4 p-6">
+        <a href="#home" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+        <div data-mobile-services>
+          <div class="flex items-center justify-between">
+            <a href="/services/" class="nav-link text-gray-700 hover:text-blue-600 transition">Services</a>
+            <button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600">
+              <i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i>
+            </button>
+          </div>
+          <div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2">
+            <a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a>
+            <a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a>
+            <a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a>
+            <a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a>
+            <a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a>
+            <a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a>
+            <a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a>
+          </div>
+        </div>
+        <a href="#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+        <a href="#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+        <a href="#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+        <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+        <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+        <a href="#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
+      </div>
     </div>
+    <!-- /bf:mobile-menu -->
 
     <!-- Hero Section -->
     <section id="home" class="hero-gradient text-white py-20" tabindex="-1">
@@ -937,80 +933,61 @@
     </section>
 
     <!-- Footer -->
+    <!-- bf:footer -->
     <footer class="bg-blue-950 text-white py-12">
-        <div class="container mx-auto px-6">
-            <div class="grid md:grid-cols-4 gap-8">
-                <div>
-                    <div class="text-2xl font-bold mb-4">
-                        <span class="text-blue-400">Blooming</span> Financial
-                    </div>
-                    <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
-                    <div class="flex space-x-4">
-                        <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer">
-                            <i class="fab fa-instagram" aria-hidden="true"></i>
-                        </a>
-                        <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer">
-                            <i class="fab fa-yelp" aria-hidden="true"></i>
-                        </a>
-                    </div>
-                    <p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p>
-                </div>
-                
-                <div>
-                    <h3 class="font-bold text-lg mb-4">Services</h3>
-                    <ul class="space-y-2">
-                        <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
-                        <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
-                        <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
-                        <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
-                        <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
-                        <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
-                        <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="font-bold text-lg mb-4">Quick Links</h3>
-                    <ul class="space-y-2">
-                        <li><a href="#home" class="text-blue-200 hover:text-white transition">Home</a></li>
-                        <li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li>
-                        <li><a href="#about" class="text-blue-200 hover:text-white transition">About Us</a></li>
-                        <li><a href="#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li>
-                        <li><a href="#contact" class="text-blue-200 hover:text-white transition">Contact</a></li>
-                        <li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li>
-                    </ul>
-                </div>
-                
-                <div>
-                    <h3 class="font-bold text-lg mb-4">Contact</h3>
-                    <ul class="space-y-2 text-blue-200">
-                        <li class="flex items-start">
-                            <i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i>
-                            <span>(408) 365-4671</span>
-                        </li>
-                        <li class="flex items-start">
-                            <i class="fas fa-envelope mt-1 mr-2 text-sm"></i>
-                            <span>info@bloomingfinancials.com</span>
-                        </li>
-                        <li class="flex items-start">
-                            <i class="fas fa-clock mt-1 mr-2 text-sm"></i>
-                            <span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span>
-                        </li>
-                    </ul>
-                </div>
+      <div class="container mx-auto px-6">
+        <div class="grid md:grid-cols-4 gap-8">
+          <div>
+            <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
+            <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
+            <div class="flex space-x-4">
+              <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+              <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
             </div>
-            
-            <div class="border-t border-blue-800 mt-12 pt-8">
-                <div class="flex flex-col md:flex-row justify-between items-center">
-                    <p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p>
-                    <div class="flex space-x-6">
-                        <a href="/privacy/" class="text-blue-300 hover:text-white text-sm">Privacy Policy</a>
-                        <a href="/terms/" class="text-blue-300 hover:text-white text-sm">Terms of Service</a>
-                    </div>
-                </div>
-            </div>
+            <p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p>
+          </div>
+          <div>
+            <h3 class="font-bold text-lg mb-4">Services</h3>
+            <ul class="space-y-2">
+              <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+              <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+              <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
+              <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
+              <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+              <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
+              <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="font-bold text-lg mb-4">Quick Links</h3>
+            <ul class="space-y-2">
+              <li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li>
+              <li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li>
+              <li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li>
+              <li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li>
+              <li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li>
+              <li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li>
+            </ul>
+          </div>
+          <div>
+            <h3 class="font-bold text-lg mb-4">Contact</h3>
+            <ul class="space-y-2 text-blue-200">
+              <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
+              <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+              <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
+            </ul>
+          </div>
         </div>
+        <div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+          <p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p>
+          <div class="flex space-x-6 text-sm">
+            <a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a>
+            <a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a>
+          </div>
+        </div>
+      </div>
     </footer>
+    <!-- /bf:footer -->
 
     <!-- Back to Top Button -->
     <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50">

--- a/services/bookkeeping/index.html
+++ b/services/bookkeeping/index.html
@@ -61,7 +61,23 @@
 
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
-  <nav class="bg-white border-0 shadow-none sticky top-0 z-50"><div class="container mx-auto px-6 py-3"><div class="flex items-center justify-between"><div class="flex items-center"><a href="/" class="text-2xl font-bold text-blue-900"><span class="text-blue-600">Blooming</span> Financial</a></div><div class="hidden md:flex items-center space-x-8"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div class="relative" data-services-menu><a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">Services<i class="fas fa-chevron-down text-xs" aria-hidden="true"></i></a><div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
+  <!-- bf:nav -->
+  <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
+    <div class="container mx-auto px-6 py-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center">
+          <a href="/" class="text-2xl font-bold text-blue-900">
+            <span class="text-blue-600">Blooming</span> Financial
+          </a>
+        </div>
+        <div class="hidden md:flex items-center space-x-8">
+          <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+          <div class="relative" data-services-menu>
+            <a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+              Services
+              <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
+            </a>
+            <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
                 <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
                     <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
                     <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
@@ -71,8 +87,52 @@
                     <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
                     <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
                 </div>
-            </div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a></div><div class="md:hidden"><button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button></div></div></div></nav>
-  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true"><div class="flex flex-col space-y-4 p-6"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div data-mobile-services><div class="flex items-center justify-between"><a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a><button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600"><i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i></button></div><div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2"><a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a><a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a><a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a><a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a><a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a><a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a><a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a></div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a></div></div>
+            </div>
+          </div>
+          <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+          <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+          <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+          <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+          <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
+        </div>
+        <div class="md:hidden">
+          <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
+        </div>
+      </div>
+    </div>
+  </nav>
+  <!-- /bf:nav -->
+  <!-- bf:mobile-menu -->
+  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
+    <div class="flex flex-col space-y-4 p-6">
+      <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+      <div data-mobile-services>
+        <div class="flex items-center justify-between">
+          <a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a>
+          <button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600">
+            <i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2">
+          <a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a>
+          <a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a>
+          <a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a>
+          <a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a>
+          <a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a>
+          <a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a>
+          <a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a>
+        </div>
+      </div>
+      <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+      <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+      <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+      <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+      <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
+    </div>
+  </div>
+  <!-- /bf:mobile-menu -->
 
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
     <div class="container mx-auto px-6 text-center max-w-4xl">
@@ -177,7 +237,61 @@
     </div>
   </section>
 
-  <footer class="bg-blue-950 text-white py-12"><div class="container mx-auto px-6"><div class="grid md:grid-cols-4 gap-8"><div><div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div><p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p><div class="flex space-x-4"><a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a><a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a></div><p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p></div><div><h3 class="font-bold text-lg mb-4">Services</h3><ul class="space-y-2"><li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li><li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li><li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li><li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li><li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li><li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li><li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Quick Links</h3><ul class="space-y-2"><li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li><li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li><li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li><li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li><li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li><li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Contact</h3><ul class="space-y-2 text-blue-200"><li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li><li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li><li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li></ul></div></div><div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"><p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p><div class="flex space-x-6 text-sm"><a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a><a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a></div></div></div></footer>
+  <!-- bf:footer -->
+  <footer class="bg-blue-950 text-white py-12">
+    <div class="container mx-auto px-6">
+      <div class="grid md:grid-cols-4 gap-8">
+        <div>
+          <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
+          <div class="flex space-x-4">
+            <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+            <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
+          </div>
+          <p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Services</h3>
+          <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
+            <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
+            <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Quick Links</h3>
+          <ul class="space-y-2">
+            <li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li>
+            <li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li>
+            <li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li>
+            <li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li>
+            <li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li>
+            <li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Contact</h3>
+          <ul class="space-y-2 text-blue-200">
+            <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
+            <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
+          </ul>
+        </div>
+      </div>
+      <div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+        <p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p>
+        <div class="flex space-x-6 text-sm">
+          <a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a>
+          <a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <!-- /bf:footer -->
 
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>
   <script>

--- a/services/business-consulting/index.html
+++ b/services/business-consulting/index.html
@@ -60,7 +60,23 @@
 
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
-  <nav class="bg-white border-0 shadow-none sticky top-0 z-50"><div class="container mx-auto px-6 py-3"><div class="flex items-center justify-between"><div class="flex items-center"><a href="/" class="text-2xl font-bold text-blue-900"><span class="text-blue-600">Blooming</span> Financial</a></div><div class="hidden md:flex items-center space-x-8"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div class="relative" data-services-menu><a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">Services<i class="fas fa-chevron-down text-xs" aria-hidden="true"></i></a><div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
+  <!-- bf:nav -->
+  <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
+    <div class="container mx-auto px-6 py-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center">
+          <a href="/" class="text-2xl font-bold text-blue-900">
+            <span class="text-blue-600">Blooming</span> Financial
+          </a>
+        </div>
+        <div class="hidden md:flex items-center space-x-8">
+          <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+          <div class="relative" data-services-menu>
+            <a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+              Services
+              <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
+            </a>
+            <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
                 <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
                     <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
                     <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
@@ -70,8 +86,52 @@
                     <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
                     <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
                 </div>
-            </div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a></div><div class="md:hidden"><button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button></div></div></div></nav>
-  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true"><div class="flex flex-col space-y-4 p-6"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div data-mobile-services><div class="flex items-center justify-between"><a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a><button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600"><i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i></button></div><div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2"><a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a><a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a><a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a><a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a><a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a><a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a><a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a></div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a></div></div>
+            </div>
+          </div>
+          <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+          <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+          <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+          <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+          <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
+        </div>
+        <div class="md:hidden">
+          <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
+        </div>
+      </div>
+    </div>
+  </nav>
+  <!-- /bf:nav -->
+  <!-- bf:mobile-menu -->
+  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
+    <div class="flex flex-col space-y-4 p-6">
+      <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+      <div data-mobile-services>
+        <div class="flex items-center justify-between">
+          <a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a>
+          <button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600">
+            <i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2">
+          <a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a>
+          <a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a>
+          <a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a>
+          <a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a>
+          <a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a>
+          <a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a>
+          <a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a>
+        </div>
+      </div>
+      <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+      <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+      <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+      <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+      <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
+    </div>
+  </div>
+  <!-- /bf:mobile-menu -->
 
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
     <div class="container mx-auto px-6 text-center max-w-4xl">
@@ -172,7 +232,61 @@
     </div>
   </section>
 
-  <footer class="bg-blue-950 text-white py-12"><div class="container mx-auto px-6"><div class="grid md:grid-cols-4 gap-8"><div><div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div><p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p><div class="flex space-x-4"><a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a><a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a></div><p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p></div><div><h3 class="font-bold text-lg mb-4">Services</h3><ul class="space-y-2"><li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li><li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li><li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li><li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li><li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li><li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li><li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Quick Links</h3><ul class="space-y-2"><li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li><li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li><li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li><li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li><li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li><li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Contact</h3><ul class="space-y-2 text-blue-200"><li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li><li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li><li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li></ul></div></div><div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"><p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p><div class="flex space-x-6 text-sm"><a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a><a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a></div></div></div></footer>
+  <!-- bf:footer -->
+  <footer class="bg-blue-950 text-white py-12">
+    <div class="container mx-auto px-6">
+      <div class="grid md:grid-cols-4 gap-8">
+        <div>
+          <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
+          <div class="flex space-x-4">
+            <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+            <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
+          </div>
+          <p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Services</h3>
+          <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
+            <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
+            <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Quick Links</h3>
+          <ul class="space-y-2">
+            <li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li>
+            <li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li>
+            <li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li>
+            <li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li>
+            <li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li>
+            <li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Contact</h3>
+          <ul class="space-y-2 text-blue-200">
+            <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
+            <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
+          </ul>
+        </div>
+      </div>
+      <div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+        <p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p>
+        <div class="flex space-x-6 text-sm">
+          <a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a>
+          <a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <!-- /bf:footer -->
 
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>
   <script>

--- a/services/business-tax-preparation/index.html
+++ b/services/business-tax-preparation/index.html
@@ -86,7 +86,23 @@
 
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
-  <nav class="bg-white border-0 shadow-none sticky top-0 z-50"><div class="container mx-auto px-6 py-3"><div class="flex items-center justify-between"><div class="flex items-center"><a href="/" class="text-2xl font-bold text-blue-900"><span class="text-blue-600">Blooming</span> Financial</a></div><div class="hidden md:flex items-center space-x-8"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div class="relative" data-services-menu><a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">Services<i class="fas fa-chevron-down text-xs" aria-hidden="true"></i></a><div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
+  <!-- bf:nav -->
+  <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
+    <div class="container mx-auto px-6 py-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center">
+          <a href="/" class="text-2xl font-bold text-blue-900">
+            <span class="text-blue-600">Blooming</span> Financial
+          </a>
+        </div>
+        <div class="hidden md:flex items-center space-x-8">
+          <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+          <div class="relative" data-services-menu>
+            <a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+              Services
+              <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
+            </a>
+            <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
                 <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
                     <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
                     <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
@@ -96,8 +112,52 @@
                     <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
                     <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
                 </div>
-            </div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a></div><div class="md:hidden"><button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button></div></div></div></nav>
-  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true"><div class="flex flex-col space-y-4 p-6"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div data-mobile-services><div class="flex items-center justify-between"><a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a><button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600"><i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i></button></div><div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2"><a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a><a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a><a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a><a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a><a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a><a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a><a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a></div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a></div></div>
+            </div>
+          </div>
+          <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+          <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+          <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+          <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+          <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
+        </div>
+        <div class="md:hidden">
+          <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
+        </div>
+      </div>
+    </div>
+  </nav>
+  <!-- /bf:nav -->
+  <!-- bf:mobile-menu -->
+  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
+    <div class="flex flex-col space-y-4 p-6">
+      <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+      <div data-mobile-services>
+        <div class="flex items-center justify-between">
+          <a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a>
+          <button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600">
+            <i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2">
+          <a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a>
+          <a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a>
+          <a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a>
+          <a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a>
+          <a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a>
+          <a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a>
+          <a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a>
+        </div>
+      </div>
+      <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+      <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+      <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+      <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+      <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
+    </div>
+  </div>
+  <!-- /bf:mobile-menu -->
 
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
     <div class="container mx-auto px-6 text-center max-w-4xl">
@@ -214,7 +274,61 @@
     </div>
   </section>
 
-  <footer class="bg-blue-950 text-white py-12"><div class="container mx-auto px-6"><div class="grid md:grid-cols-4 gap-8"><div><div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div><p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p><div class="flex space-x-4"><a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a><a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a></div><p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p></div><div><h3 class="font-bold text-lg mb-4">Services</h3><ul class="space-y-2"><li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li><li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li><li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li><li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li><li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li><li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li><li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Quick Links</h3><ul class="space-y-2"><li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li><li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li><li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li><li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li><li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li><li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Contact</h3><ul class="space-y-2 text-blue-200"><li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li><li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li><li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li></ul></div></div><div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"><p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p><div class="flex space-x-6 text-sm"><a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a><a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a></div></div></div></footer>
+  <!-- bf:footer -->
+  <footer class="bg-blue-950 text-white py-12">
+    <div class="container mx-auto px-6">
+      <div class="grid md:grid-cols-4 gap-8">
+        <div>
+          <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
+          <div class="flex space-x-4">
+            <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+            <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
+          </div>
+          <p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Services</h3>
+          <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
+            <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
+            <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Quick Links</h3>
+          <ul class="space-y-2">
+            <li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li>
+            <li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li>
+            <li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li>
+            <li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li>
+            <li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li>
+            <li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Contact</h3>
+          <ul class="space-y-2 text-blue-200">
+            <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
+            <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
+          </ul>
+        </div>
+      </div>
+      <div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+        <p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p>
+        <div class="flex space-x-6 text-sm">
+          <a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a>
+          <a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <!-- /bf:footer -->
 
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>
   <script>

--- a/services/index.html
+++ b/services/index.html
@@ -115,6 +115,7 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- NAV -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
@@ -155,7 +156,9 @@
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
 
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -184,6 +187,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- HERO -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -343,6 +347,7 @@
   </section>
 
   <!-- FOOTER -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -396,6 +401,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>
 

--- a/services/individual-tax-preparation/index.html
+++ b/services/individual-tax-preparation/index.html
@@ -104,10 +104,15 @@
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
   <!-- NAV -->
+  <!-- bf:nav -->
   <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
     <div class="container mx-auto px-6 py-3">
       <div class="flex items-center justify-between">
-        <div class="flex items-center"><a href="/" class="text-2xl font-bold text-blue-900"><span class="text-blue-600">Blooming</span> Financial</a></div>
+        <div class="flex items-center">
+          <a href="/" class="text-2xl font-bold text-blue-900">
+            <span class="text-blue-600">Blooming</span> Financial
+          </a>
+        </div>
         <div class="hidden md:flex items-center space-x-8">
           <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
           <div class="relative" data-services-menu>
@@ -134,10 +139,14 @@
           <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
           <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
         </div>
-        <div class="md:hidden"><button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button></div>
+        <div class="md:hidden">
+          <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
+        </div>
       </div>
     </div>
   </nav>
+  <!-- /bf:nav -->
+  <!-- bf:mobile-menu -->
   <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
     <div class="flex flex-col space-y-4 p-6">
       <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
@@ -166,6 +175,7 @@
       <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
     </div>
   </div>
+  <!-- /bf:mobile-menu -->
 
   <!-- HERO -->
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
@@ -299,6 +309,7 @@
   </section>
 
   <!-- FOOTER -->
+  <!-- bf:footer -->
   <footer class="bg-blue-950 text-white py-12">
     <div class="container mx-auto px-6">
       <div class="grid md:grid-cols-4 gap-8">
@@ -352,6 +363,7 @@
       </div>
     </div>
   </footer>
+  <!-- /bf:footer -->
 
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>
 

--- a/services/irs-ftb-notice-support/index.html
+++ b/services/irs-ftb-notice-support/index.html
@@ -61,7 +61,23 @@
 
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
-  <nav class="bg-white border-0 shadow-none sticky top-0 z-50"><div class="container mx-auto px-6 py-3"><div class="flex items-center justify-between"><div class="flex items-center"><a href="/" class="text-2xl font-bold text-blue-900"><span class="text-blue-600">Blooming</span> Financial</a></div><div class="hidden md:flex items-center space-x-8"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div class="relative" data-services-menu><a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">Services<i class="fas fa-chevron-down text-xs" aria-hidden="true"></i></a><div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
+  <!-- bf:nav -->
+  <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
+    <div class="container mx-auto px-6 py-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center">
+          <a href="/" class="text-2xl font-bold text-blue-900">
+            <span class="text-blue-600">Blooming</span> Financial
+          </a>
+        </div>
+        <div class="hidden md:flex items-center space-x-8">
+          <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+          <div class="relative" data-services-menu>
+            <a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+              Services
+              <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
+            </a>
+            <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
                 <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
                     <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
                     <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
@@ -71,8 +87,52 @@
                     <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
                     <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
                 </div>
-            </div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a></div><div class="md:hidden"><button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button></div></div></div></nav>
-  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true"><div class="flex flex-col space-y-4 p-6"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div data-mobile-services><div class="flex items-center justify-between"><a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a><button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600"><i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i></button></div><div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2"><a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a><a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a><a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a><a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a><a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a><a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a><a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a></div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a></div></div>
+            </div>
+          </div>
+          <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+          <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+          <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+          <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+          <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
+        </div>
+        <div class="md:hidden">
+          <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
+        </div>
+      </div>
+    </div>
+  </nav>
+  <!-- /bf:nav -->
+  <!-- bf:mobile-menu -->
+  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
+    <div class="flex flex-col space-y-4 p-6">
+      <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+      <div data-mobile-services>
+        <div class="flex items-center justify-between">
+          <a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a>
+          <button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600">
+            <i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2">
+          <a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a>
+          <a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a>
+          <a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a>
+          <a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a>
+          <a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a>
+          <a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a>
+          <a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a>
+        </div>
+      </div>
+      <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+      <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+      <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+      <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+      <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
+    </div>
+  </div>
+  <!-- /bf:mobile-menu -->
 
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
     <div class="container mx-auto px-6 text-center max-w-4xl">
@@ -185,7 +245,61 @@
     </div>
   </section>
 
-  <footer class="bg-blue-950 text-white py-12"><div class="container mx-auto px-6"><div class="grid md:grid-cols-4 gap-8"><div><div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div><p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p><div class="flex space-x-4"><a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a><a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a></div><p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p></div><div><h3 class="font-bold text-lg mb-4">Services</h3><ul class="space-y-2"><li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li><li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li><li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li><li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li><li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li><li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li><li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Quick Links</h3><ul class="space-y-2"><li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li><li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li><li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li><li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li><li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li><li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Contact</h3><ul class="space-y-2 text-blue-200"><li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li><li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li><li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li></ul></div></div><div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"><p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p><div class="flex space-x-6 text-sm"><a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a><a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a></div></div></div></footer>
+  <!-- bf:footer -->
+  <footer class="bg-blue-950 text-white py-12">
+    <div class="container mx-auto px-6">
+      <div class="grid md:grid-cols-4 gap-8">
+        <div>
+          <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
+          <div class="flex space-x-4">
+            <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+            <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
+          </div>
+          <p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Services</h3>
+          <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
+            <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
+            <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Quick Links</h3>
+          <ul class="space-y-2">
+            <li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li>
+            <li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li>
+            <li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li>
+            <li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li>
+            <li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li>
+            <li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Contact</h3>
+          <ul class="space-y-2 text-blue-200">
+            <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
+            <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
+          </ul>
+        </div>
+      </div>
+      <div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+        <p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p>
+        <div class="flex space-x-6 text-sm">
+          <a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a>
+          <a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <!-- /bf:footer -->
 
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>
   <script>

--- a/services/payroll/index.html
+++ b/services/payroll/index.html
@@ -60,7 +60,23 @@
 
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
-  <nav class="bg-white border-0 shadow-none sticky top-0 z-50"><div class="container mx-auto px-6 py-3"><div class="flex items-center justify-between"><div class="flex items-center"><a href="/" class="text-2xl font-bold text-blue-900"><span class="text-blue-600">Blooming</span> Financial</a></div><div class="hidden md:flex items-center space-x-8"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div class="relative" data-services-menu><a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">Services<i class="fas fa-chevron-down text-xs" aria-hidden="true"></i></a><div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
+  <!-- bf:nav -->
+  <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
+    <div class="container mx-auto px-6 py-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center">
+          <a href="/" class="text-2xl font-bold text-blue-900">
+            <span class="text-blue-600">Blooming</span> Financial
+          </a>
+        </div>
+        <div class="hidden md:flex items-center space-x-8">
+          <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+          <div class="relative" data-services-menu>
+            <a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+              Services
+              <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
+            </a>
+            <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
                 <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
                     <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
                     <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
@@ -70,8 +86,52 @@
                     <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
                     <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
                 </div>
-            </div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a></div><div class="md:hidden"><button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button></div></div></div></nav>
-  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true"><div class="flex flex-col space-y-4 p-6"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div data-mobile-services><div class="flex items-center justify-between"><a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a><button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600"><i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i></button></div><div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2"><a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a><a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a><a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a><a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a><a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a><a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a><a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a></div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a></div></div>
+            </div>
+          </div>
+          <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+          <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+          <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+          <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+          <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
+        </div>
+        <div class="md:hidden">
+          <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
+        </div>
+      </div>
+    </div>
+  </nav>
+  <!-- /bf:nav -->
+  <!-- bf:mobile-menu -->
+  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
+    <div class="flex flex-col space-y-4 p-6">
+      <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+      <div data-mobile-services>
+        <div class="flex items-center justify-between">
+          <a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a>
+          <button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600">
+            <i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2">
+          <a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a>
+          <a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a>
+          <a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a>
+          <a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a>
+          <a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a>
+          <a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a>
+          <a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a>
+        </div>
+      </div>
+      <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+      <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+      <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+      <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+      <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
+    </div>
+  </div>
+  <!-- /bf:mobile-menu -->
 
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
     <div class="container mx-auto px-6 text-center max-w-4xl">
@@ -172,7 +232,61 @@
     </div>
   </section>
 
-  <footer class="bg-blue-950 text-white py-12"><div class="container mx-auto px-6"><div class="grid md:grid-cols-4 gap-8"><div><div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div><p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p><div class="flex space-x-4"><a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a><a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a></div><p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p></div><div><h3 class="font-bold text-lg mb-4">Services</h3><ul class="space-y-2"><li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li><li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li><li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li><li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li><li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li><li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li><li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Quick Links</h3><ul class="space-y-2"><li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li><li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li><li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li><li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li><li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li><li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Contact</h3><ul class="space-y-2 text-blue-200"><li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li><li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li><li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li></ul></div></div><div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"><p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p><div class="flex space-x-6 text-sm"><a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a><a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a></div></div></div></footer>
+  <!-- bf:footer -->
+  <footer class="bg-blue-950 text-white py-12">
+    <div class="container mx-auto px-6">
+      <div class="grid md:grid-cols-4 gap-8">
+        <div>
+          <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
+          <div class="flex space-x-4">
+            <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+            <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
+          </div>
+          <p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Services</h3>
+          <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
+            <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
+            <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Quick Links</h3>
+          <ul class="space-y-2">
+            <li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li>
+            <li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li>
+            <li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li>
+            <li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li>
+            <li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li>
+            <li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Contact</h3>
+          <ul class="space-y-2 text-blue-200">
+            <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
+            <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
+          </ul>
+        </div>
+      </div>
+      <div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+        <p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p>
+        <div class="flex space-x-6 text-sm">
+          <a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a>
+          <a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <!-- /bf:footer -->
 
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>
   <script>

--- a/services/tax-planning/index.html
+++ b/services/tax-planning/index.html
@@ -61,7 +61,23 @@
 
 <body class="bg-gray-50">
   <a href="#main-content" class="sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-[100] focus:bg-white focus:text-blue-700 focus:px-4 focus:py-2 focus:rounded-md focus:shadow-lg">Skip to main content</a>
-  <nav class="bg-white border-0 shadow-none sticky top-0 z-50"><div class="container mx-auto px-6 py-3"><div class="flex items-center justify-between"><div class="flex items-center"><a href="/" class="text-2xl font-bold text-blue-900"><span class="text-blue-600">Blooming</span> Financial</a></div><div class="hidden md:flex items-center space-x-8"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div class="relative" data-services-menu><a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">Services<i class="fas fa-chevron-down text-xs" aria-hidden="true"></i></a><div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
+  <!-- bf:nav -->
+  <nav class="bg-white border-0 shadow-none sticky top-0 z-50">
+    <div class="container mx-auto px-6 py-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center">
+          <a href="/" class="text-2xl font-bold text-blue-900">
+            <span class="text-blue-600">Blooming</span> Financial
+          </a>
+        </div>
+        <div class="hidden md:flex items-center space-x-8">
+          <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+          <div class="relative" data-services-menu>
+            <a href="/services/" class="nav-link text-blue-600 font-semibold inline-flex items-center gap-1" aria-haspopup="true" aria-expanded="false">
+              Services
+              <i class="fas fa-chevron-down text-xs" aria-hidden="true"></i>
+            </a>
+            <div data-services-panel class="absolute left-0 top-full pt-2 w-80 hidden z-50">
                 <div class="bg-white rounded-xl border border-gray-100 shadow-xl shadow-blue-900/10 ring-1 ring-black/5 p-2">
                     <a href="/services/individual-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Individual Tax Preparation</a>
                     <a href="/services/business-tax-preparation/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Tax Preparation</a>
@@ -71,8 +87,52 @@
                     <a href="/services/irs-ftb-notice-support/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">IRS &amp; FTB Notice Support</a>
                     <a href="/services/business-consulting/" class="block rounded-lg px-4 py-2.5 text-sm text-gray-700 hover:bg-blue-50 hover:text-blue-700">Business Consulting</a>
                 </div>
-            </div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a></div><div class="md:hidden"><button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button></div></div></div></nav>
-  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true"><div class="flex flex-col space-y-4 p-6"><a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a><div data-mobile-services><div class="flex items-center justify-between"><a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a><button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600"><i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i></button></div><div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2"><a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a><a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a><a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a><a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a><a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a><a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a><a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a></div></div><a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a><a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a><a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a><a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a><a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a><a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a></div></div>
+            </div>
+          </div>
+          <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+          <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+          <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+          <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+          <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+          <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition">Free Consultation</a>
+        </div>
+        <div class="md:hidden">
+          <button id="mobileToggle" class="text-gray-700 focus:outline-none"><i class="fas fa-bars text-2xl"></i></button>
+        </div>
+      </div>
+    </div>
+  </nav>
+  <!-- /bf:nav -->
+  <!-- bf:mobile-menu -->
+  <div id="mobileMenu" class="fixed inset-x-0 top-14 w-full bg-white transform -translate-y-full opacity-0 invisible pointer-events-none transition-all duration-300 ease-in-out z-40 md:hidden" aria-hidden="true">
+    <div class="flex flex-col space-y-4 p-6">
+      <a href="/" class="nav-link text-gray-700 hover:text-blue-600 transition">Home</a>
+      <div data-mobile-services>
+        <div class="flex items-center justify-between">
+          <a href="/services/" class="nav-link text-blue-600 font-semibold">Services</a>
+          <button type="button" data-mobile-services-toggle aria-expanded="false" aria-label="Toggle services menu" class="p-2 text-gray-500 hover:text-blue-600">
+            <i class="fas fa-chevron-down text-sm transition-transform" aria-hidden="true"></i>
+          </button>
+        </div>
+        <div data-mobile-services-panel class="hidden flex-col space-y-2 pl-4 mt-2">
+          <a href="/services/individual-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Individual Tax Preparation</a>
+          <a href="/services/business-tax-preparation/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Tax Preparation</a>
+          <a href="/services/tax-planning/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Tax Planning</a>
+          <a href="/services/bookkeeping/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Bookkeeping</a>
+          <a href="/services/payroll/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Payroll</a>
+          <a href="/services/irs-ftb-notice-support/" class="text-gray-600 hover:text-blue-600 transition py-1 block">IRS &amp; FTB Notice Support</a>
+          <a href="/services/business-consulting/" class="text-gray-600 hover:text-blue-600 transition py-1 block">Business Consulting</a>
+        </div>
+      </div>
+      <a href="/#about" class="nav-link text-gray-700 hover:text-blue-600 transition">About</a>
+      <a href="/#testimonials" class="nav-link text-gray-700 hover:text-blue-600 transition">Testimonials</a>
+      <a href="/#contact" class="nav-link text-gray-700 hover:text-blue-600 transition">Contact</a>
+      <a href="/blogs/" class="nav-link text-gray-700 hover:text-blue-600 transition">Blogs</a>
+      <a href="https://portal.bloomingfinancials.com" class="nav-link text-gray-700 hover:text-blue-600 transition" target="_blank" rel="noopener noreferrer">Client Portal</a>
+      <a href="/#consultation" class="bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 transition text-center">Free Consultation</a>
+    </div>
+  </div>
+  <!-- /bf:mobile-menu -->
 
   <header id="main-content" tabindex="-1" class="hero-gradient text-white py-20">
     <div class="container mx-auto px-6 text-center max-w-4xl">
@@ -189,7 +249,61 @@
     </div>
   </section>
 
-  <footer class="bg-blue-950 text-white py-12"><div class="container mx-auto px-6"><div class="grid md:grid-cols-4 gap-8"><div><div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div><p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p><div class="flex space-x-4"><a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a><a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a></div><p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p></div><div><h3 class="font-bold text-lg mb-4">Services</h3><ul class="space-y-2"><li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li><li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li><li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li><li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li><li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li><li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li><li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Quick Links</h3><ul class="space-y-2"><li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li><li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li><li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li><li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li><li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li><li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li></ul></div><div><h3 class="font-bold text-lg mb-4">Contact</h3><ul class="space-y-2 text-blue-200"><li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li><li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li><li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li></ul></div></div><div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center"><p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p><div class="flex space-x-6 text-sm"><a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a><a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a></div></div></div></footer>
+  <!-- bf:footer -->
+  <footer class="bg-blue-950 text-white py-12">
+    <div class="container mx-auto px-6">
+      <div class="grid md:grid-cols-4 gap-8">
+        <div>
+          <div class="text-2xl font-bold mb-4"><span class="text-blue-400">Blooming</span> Financial</div>
+          <p class="text-blue-200 mb-4">Professional financial services for individuals and small businesses in California.</p>
+          <div class="flex space-x-4">
+            <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Instagram (@bloomingfinancial)" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram" aria-hidden="true"></i></a>
+            <a href="https://www.yelp.com/biz/blooming-financial-cupertino" class="text-blue-300 hover:text-white text-xl" aria-label="Blooming Financial on Yelp" target="_blank" rel="noopener noreferrer"><i class="fab fa-yelp" aria-hidden="true"></i></a>
+          </div>
+          <p class="text-blue-200 text-sm mt-3">Instagram: <a href="https://www.instagram.com/bloomingfinancial/" class="text-blue-100 hover:text-white" target="_blank" rel="noopener noreferrer">@bloomingfinancial</a></p>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Services</h3>
+          <ul class="space-y-2">
+            <li><a href="/services/individual-tax-preparation/" class="text-blue-200 hover:text-white transition">Individual Tax Preparation</a></li>
+            <li><a href="/services/business-tax-preparation/" class="text-blue-200 hover:text-white transition">Business Tax Preparation</a></li>
+            <li><a href="/services/tax-planning/" class="text-blue-200 hover:text-white transition">Tax Planning</a></li>
+            <li><a href="/services/bookkeeping/" class="text-blue-200 hover:text-white transition">Bookkeeping</a></li>
+            <li><a href="/services/payroll/" class="text-blue-200 hover:text-white transition">Payroll</a></li>
+            <li><a href="/services/irs-ftb-notice-support/" class="text-blue-200 hover:text-white transition">IRS &amp; FTB Notice Support</a></li>
+            <li><a href="/services/business-consulting/" class="text-blue-200 hover:text-white transition">Business Consulting</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Quick Links</h3>
+          <ul class="space-y-2">
+            <li><a href="/" class="text-blue-200 hover:text-white transition">Home</a></li>
+            <li><a href="/services/" class="text-blue-200 hover:text-white transition">Services</a></li>
+            <li><a href="/#about" class="text-blue-200 hover:text-white transition">About Us</a></li>
+            <li><a href="/#testimonials" class="text-blue-200 hover:text-white transition">Testimonials</a></li>
+            <li><a href="/#contact" class="text-blue-200 hover:text-white transition">Contact</a></li>
+            <li><a href="/blogs/" class="text-blue-200 hover:text-white transition">Blogs</a></li>
+          </ul>
+        </div>
+        <div>
+          <h3 class="font-bold text-lg mb-4">Contact</h3>
+          <ul class="space-y-2 text-blue-200">
+            <li class="flex items-start"><i class="fas fa-phone-alt mt-1 mr-2 text-sm"></i><span>(408) 365-4671</span></li>
+            <li class="flex items-start"><i class="fas fa-envelope mt-1 mr-2 text-sm"></i><span>info@bloomingfinancials.com</span></li>
+            <li class="flex items-start"><i class="fas fa-clock mt-1 mr-2 text-sm"></i><span>Mon–Fri: 8am–7pm<br>Sat: 8am–4pm<br>Sun: Closed</span></li>
+          </ul>
+        </div>
+      </div>
+      <div class="border-t border-blue-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
+        <p class="text-blue-300 text-sm mb-4 md:mb-0">© 2026 Blooming Financial. All rights reserved.</p>
+        <div class="flex space-x-6 text-sm">
+          <a href="/privacy/" class="text-blue-300 hover:text-white">Privacy Policy</a>
+          <a href="/terms/" class="text-blue-300 hover:text-white">Terms of Service</a>
+        </div>
+      </div>
+    </div>
+  </footer>
+  <!-- /bf:footer -->
 
   <button id="backToTop" class="hidden fixed bottom-6 left-6 bg-blue-600 text-white w-12 h-12 rounded-full shadow-lg hover:bg-blue-700 transition z-50"><i class="fas fa-arrow-up"></i></button>
   <script>

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Stamp shared partials (_partials/*.html) into the site's HTML pages.
+
+The nav, mobile menu, and footer are identical across the 17 full-nav pages
+except for per-page link targets and which nav item is active. Each page
+marks where a partial belongs with sentinel comments:
+
+    <!-- bf:nav -->
+    ...generated, do not hand-edit...
+    <!-- /bf:nav -->
+
+Run `python3 tools/build.py` after editing a partial to restamp every page.
+Run `python3 tools/build.py --check` (CI does) to fail if any page's stamped
+block has drifted from its partial.
+
+Privacy and Terms keep their intentionally lightweight header/footer and are
+not managed by this script.
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PARTIALS = {name: (ROOT / '_partials' / f'{name}.html').read_text().rstrip('\n')
+            for name in ('nav', 'mobile-menu', 'footer')}
+
+REGULAR = 'nav-link text-gray-700 hover:text-blue-600 transition'
+ACTIVE = 'nav-link text-blue-600 font-semibold'
+
+HOME_VARS = {
+    'HOME_HREF': '#home', 'ABOUT_HREF': '#about', 'TESTIMONIALS_HREF': '#testimonials',
+    'CONTACT_HREF': '#contact', 'CONSULTATION_HREF': '#consultation',
+}
+SUB_VARS = {
+    'HOME_HREF': '/', 'ABOUT_HREF': '/#about', 'TESTIMONIALS_HREF': '/#testimonials',
+    'CONTACT_HREF': '/#contact', 'CONSULTATION_HREF': '/#consultation',
+}
+
+def page_vars(rel: str) -> dict:
+    v = dict(HOME_VARS if rel == 'index.html' else SUB_VARS)
+    v['SERVICES_CLS'] = ACTIVE if rel.startswith('services/') else REGULAR
+    v['BLOGS_CLS'] = ACTIVE if rel.startswith('blogs/') else REGULAR
+    return v
+
+PAGES = [
+    'index.html',
+    'services/index.html',
+    'services/individual-tax-preparation/index.html',
+    'services/business-tax-preparation/index.html',
+    'services/tax-planning/index.html',
+    'services/bookkeeping/index.html',
+    'services/payroll/index.html',
+    'services/irs-ftb-notice-support/index.html',
+    'services/business-consulting/index.html',
+    'blogs/index.html',
+    'blogs/startup-tax-deductions.html',
+    'blogs/payroll-compliance-checklist-california.html',
+    'blogs/top-tax-credits-california-families.html',
+    'blogs/llc-s-corp-c-corp-california.html',
+    'blogs/w4-de4-withholding-guide-california.html',
+    'blogs/rsus-stock-sales-explained.html',
+    'blogs/2025-tax-law-changes.html',
+]
+
+
+def render(name: str, variables: dict, indent: str) -> str:
+    out = PARTIALS[name]
+    for key, val in variables.items():
+        out = out.replace('{{%s}}' % key, val)
+    leftover = re.search(r'\{\{[A-Z_]+\}\}', out)
+    if leftover:
+        raise SystemExit(f'unsubstituted token {leftover.group(0)} in partial {name}')
+    return '\n'.join(indent + line if line.strip() else line
+                     for line in out.splitlines())
+
+
+def stamp(text: str, rel: str) -> str:
+    variables = page_vars(rel)
+    for name in PARTIALS:
+        pattern = re.compile(
+            r'^([ \t]*)<!-- bf:%s -->\n(?:.*?\n)?[ \t]*<!-- /bf:%s -->' % (name, name),
+            re.DOTALL | re.MULTILINE)
+        m = pattern.search(text)
+        if not m:
+            raise SystemExit(f'{rel}: missing sentinel block bf:{name}')
+        indent = m.group(1)
+        block = (f'{indent}<!-- bf:{name} -->\n'
+                 f'{render(name, variables, indent)}\n'
+                 f'{indent}<!-- /bf:{name} -->')
+        text = text[:m.start()] + block + text[m.end():]
+    return text
+
+
+def main() -> int:
+    check = '--check' in sys.argv
+    drifted = []
+    for rel in PAGES:
+        path = ROOT / rel
+        current = path.read_text()
+        stamped = stamp(current, rel)
+        if stamped != current:
+            if check:
+                drifted.append(rel)
+            else:
+                path.write_text(stamped)
+                print(f'stamped  {rel}')
+    if check:
+        if drifted:
+            print('Pages out of sync with _partials/ (run: python3 tools/build.py):')
+            for rel in drifted:
+                print(f'  - {rel}')
+            return 1
+        print(f'All {len(PAGES)} pages in sync with partials.')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/check.py
+++ b/tools/check.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Static sanity checks for the site. CI runs this on every PR.
+
+1. Every inline <script> on every page must parse (node --check). A missing
+   `});` once silently disabled all nav JS on six service pages.
+2. <div> open/close tags must balance inside each page's <nav> blocks and
+   #mobileMenu panel. Two stray </div>s once dumped half the nav links out
+   of the flex row on fifteen pages.
+"""
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+failures = []
+
+
+def html_files():
+    for f in sorted(ROOT.rglob('*.html')):
+        s = str(f)
+        if '/.git/' in s or 'node_modules' in s:
+            continue
+        yield f
+
+
+def check_inline_js():
+    checked = 0
+    for f in html_files():
+        text = f.read_text()
+        for i, script in enumerate(re.findall(r'<script>(.*?)</script>', text, re.DOTALL), 1):
+            if not script.strip():
+                continue
+            checked += 1
+            with tempfile.NamedTemporaryFile(suffix='.js', mode='w', delete=False) as tmp:
+                tmp.write(script)
+                name = tmp.name
+            r = subprocess.run(['node', '--check', name], capture_output=True, text=True)
+            if r.returncode != 0:
+                err = r.stderr.strip().splitlines()[-1] if r.stderr else 'unknown'
+                failures.append(f'{f.relative_to(ROOT)} script #{i}: {err}')
+    print(f'inline JS: {checked} scripts checked')
+
+
+def div_balance(snippet: str) -> int:
+    depth = 0
+    for m in re.finditer(r'<(/?)div\b[^>]*>', snippet):
+        depth += -1 if m.group(1) else 1
+    return depth
+
+
+def check_nav_nesting():
+    checked = 0
+    for f in html_files():
+        text = f.read_text()
+        rel = f.relative_to(ROOT)
+        for m in re.finditer(r'<nav\b[^>]*>.*?</nav>', text, re.DOTALL):
+            checked += 1
+            d = div_balance(m.group(0))
+            if d != 0:
+                failures.append(f'{rel}: <nav> block div balance is {d:+d}')
+        s = text.find('<div id="mobileMenu"')
+        if s != -1:
+            # End of menu = where depth returns to zero; verify it closes at all.
+            depth = 0
+            closed = False
+            for m in re.finditer(r'<(/?)div\b[^>]*>', text[s:]):
+                depth += -1 if m.group(1) else 1
+                if depth == 0:
+                    closed = True
+                    break
+            checked += 1
+            if not closed:
+                failures.append(f'{rel}: #mobileMenu div never closes')
+    print(f'nav nesting: {checked} blocks checked')
+
+
+def main() -> int:
+    check_inline_js()
+    check_nav_nesting()
+    if failures:
+        print('\nFAILURES:')
+        for f in failures:
+            print(f'  - {f}')
+        return 1
+    print('all checks passed')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
Last of four stacked PRs. **Merge after PR #51.**

The nav, mobile menu, and footer existed as 17 hand-maintained copies — the duplication behind three past incidents (stray `</div>`s breaking the nav row on 15 pages, a missing `});` silently killing nav JS on 6 pages, and every global nav change touching 17+ files).

- `_partials/nav.html`, `mobile-menu.html`, `footer.html` hold the canonical markup. Per-page variation is reduced to link targets (homepage `#anchors` vs subpage `/#anchors`) and the active nav item — computed by `tools/build.py`, which stamps the blocks between `<!-- bf:* -->` sentinels. Edit the partial → `python3 tools/build.py` → every page updates.
- Migration verified with a token-level diff against the pre-migration markup: only intended deltas (homepage hamburger gains the canonical `id="mobileToggle"`; homepage footer anchors become the equivalent absolute form). The six minified service pages are now readable.
- Privacy/Terms keep their intentionally lightweight header/footer, unmanaged.
- **CI** (`.github/workflows/checks.yml`) on every PR: partial-drift check, `node --check` on all inline scripts, div-balance on every nav block (the two past incident classes), and a Tailwind rebuild diffed against the committed stylesheet.
- README + DESIGN.md updated to document the workflow.

https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf

---
_Generated by [Claude Code](https://claude.ai/code/session_01V4YGhaYn8DhnCXasZcNqMf)_